### PR TITLE
🐛Found the culprit for fresh login issue

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -65,10 +65,10 @@ def secure_user_endpoint(
     user_data = UserCreateIn(
         name=name,
         email=email,
-        # info={
-        #     "sign_in_provider": raw_data['firebase'].get("sign_in_provider"),
-        #     "picture": picture
-        # }
+        info={
+            "sign_in_provider": raw_data['firebase'].get("sign_in_provider"),
+            "picture": picture
+        }
     )
 
     user = crud.user.get_or_create(session, user_data)


### PR DESCRIPTION
Haven't been able to log into the Admin UI, upon further investigation my fresh SSO-created account had been given a null "info" json.
The api was then attempting to assign a picture url etc to the null object during auth (api/auth.py:86) and throwing null reference errors.
Returning the info json creation from behind a comment solved the problem, hasn't appeared to have created any more.

Just wondering if the comment was an artefact from dev or if it had a deeper implication.