### PR TITLE
Add library dashboard deployment url for testing

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -67,8 +67,9 @@ class Settings(BaseSettings):
         "http://localhost:8000",
         "http://127.0.0.1:8000",
 
-        # Production URL
+        # Production URLs
         "https://api.wriveted.com",
+        "https://wriveted-library.web.app",
 
         # Production Cloud Run Deployments - Direct URLs
         "https://wriveted-admin-ui-lg5ntws4da-ts.a.run.app",


### PR DESCRIPTION
Simply added a CORS url for the firebase deployment of the unfinished library frontend.