### PR TITLE
Bugfix/dockefile cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ COPY app/ /app/app
 # Now install the application itself
 RUN bash -c "if [ $INSTALL_DEV == 'true' ] ; then poetry install ; else poetry install --no-dev ; fi ;\
              rm -rf ~/.cache/pypoetry/{cache,artifacts}"
+
 ENV PYTHONPATH=/app \
     PORT=8000
 


### PR DESCRIPTION
The `PORT` env var wasn't being interpolated in CMD with the JSON format. There are ways to do it but it's hacky, but for now to get the build passing I reverted to the previous format and added the hadolint ignore rule. Will squash merge