### PR TITLE
Add public api to see if a school id exists (...)

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -3,6 +3,7 @@ from app.api.version import router as version_router
 from app.api.editions import router as edition_router
 from app.api.works import router as work_router
 from app.api.schools import router as school_router
+from app.api.schools import public_router as school_router_public
 from app.api.authors import router as author_router
 from app.api.illustrators import router as illustrator_router
 from app.api.collections import router as collections_router
@@ -21,6 +22,7 @@ api_router.include_router(author_router)
 api_router.include_router(illustrator_router)
 api_router.include_router(edition_router)
 api_router.include_router(school_router)
+api_router.include_router(school_router_public)
 api_router.include_router(work_router)
 api_router.include_router(collections_router)
 api_router.include_router(service_account_router)

--- a/app/api/schools.py
+++ b/app/api/schools.py
@@ -29,6 +29,10 @@ router = APIRouter(
     ]
 )
 
+public_router = APIRouter(
+    tags=["Public", "Schools"]
+)
+
 bulk_school_access_control_list = [
     (Allow, Authenticated, "read"),
     # if a user finds their school in the list,
@@ -107,6 +111,15 @@ async def get_school(school: School = Permission("read", get_school_from_wrivete
     Detail on a particular school
     """
     return school
+
+
+@public_router.get("/school/{wriveted_identifier}/exists")
+async def get_school(school: School = Depends(get_school_from_wriveted_id)):
+    """
+    Whether or not a school exists. Used for the publicly-accessible Bookbot chat links.
+    """
+    # dependency will automatically 404 if school doesn't exist
+    return True
 
 
 # Intended to be deprecated if wriveted_identifier is promoted to primary key


### PR DESCRIPTION
Allows app to check if the current url (of a bookbot page) actually corresponds with a school, so it can either fetch a Landbot wrapper or produce a 404.