### PR TITLE
run linters YAML on push than just PRs

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,5 +1,5 @@
 name: linters
-on: [pull_request]
+on: push 
 jobs:
   hadolint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR ensures the `linters.yml` runs on `push` rather than just PRs. 

https://github.com/Wriveted/wriveted-api/actions/runs/1856610610 ran on a push before this PR was created