### PR TITLE
CORS regex string for dashboard preview channels

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -95,6 +95,8 @@ if settings.BACKEND_CORS_ORIGINS:
     app.add_middleware(
         CORSMiddleware,
         allow_origins=[str(origin) for origin in settings.BACKEND_CORS_ORIGINS],
+        # allow preview channels from library dashboard app frontend
+        allow_origin_regex='https:\/\/wriveted-library--pr.*web\.app',
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],


### PR DESCRIPTION
To allow the dashboard app's preview channels to access the API.

Tested and working btw, dunno why the black linter fails on line 1 sometimes