### PR TITLE
add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# python byete-compiled
+# python byte-compiled
 __pycache__/
 *.py[cod]
 *$py.class


### PR DESCRIPTION
Add `gitignore` so I don't accidentally commit certain unwanted files pertaining to the text editor and python files.

I didn't ignore `poetry.lock`, according to the [docs](https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control) we should be comitting the file?