### PR TITLE
Configure the database connection pool to not reuse old connections

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -19,18 +19,15 @@ def database_connection(
         database_uri,
         # Pool size is the maximum number of permanent connections to keep.
         # defaults to 5
-        #pool_size=5,
-
+        # pool_size=5,
         # Temporarily exceeds the set pool_size if no connections are available.
         # Default is 10
         max_overflow=2,
-
         # 'pool_recycle' is the maximum number of seconds a connection can persist.
         # Connections that live longer than the specified amount of time will be
         # reestablished on checkout.
         # https://docs.sqlalchemy.org/en/14/core/pooling.html#setting-pool-recycle
         pool_recycle=900,  # 15 minutes,
-
         # 'pool_timeout' is the maximum number of seconds to wait when retrieving a
         # new connection from the pool. After the specified amount of time, an
         # exception will be thrown.


### PR DESCRIPTION
Hoping this will fix the occasional failure we see e.g. https://console.cloud.google.com/monitoring/alerting/incidents/0.mf5fqf8397ab?project=wriveted-api