### PR TITLE
Edition serialization fix

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -89,7 +89,7 @@ class Settings(BaseSettings):
         # TypeBot
         "https://typebot.io",
         "http://13.38.101.232",
-        "http://15.188.52.37"
+        "http://15.188.52.37",
     ]
 
     @validator("BACKEND_CORS_ORIGINS", pre=True)

--- a/app/schemas/edition.py
+++ b/app/schemas/edition.py
@@ -66,7 +66,7 @@ class EditionDetail(EditionBrief):
     date_published: Optional[int]
     info: Optional[EditionInfo]
 
-    @validator('authors', 'illustrators', pre=True)
+    @validator("authors", "illustrators", pre=True)
     def contributors_not_none(cls, v):
         return v or []
 


### PR DESCRIPTION
Adds a validator to EditionDetail to return an empty list instead of `None` for authors and illustrators

Fixes WRI-55