### PR TITLE
Validation fix for work info

### DIFF
--- a/app/schemas/work.py
+++ b/app/schemas/work.py
@@ -10,7 +10,7 @@ from app.schemas.labelset import LabelSetDetail
 class WorkInfo(BaseModel):
     genres: list[Genre]
     other: dict
-        
+
     @validator("genres", pre=True)
     def genres_not_none(cls, v):
         return v or []


### PR DESCRIPTION
To fix an admin ui crash on `/work/{id}` page when no genres are present on specified work