### PR TITLE
use SHELL instead of inlining + update CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,4 @@ RUN python3 -m venv ${VIRTUAL_ENV} \
 # If we would rather have multiple processes in our container
 # Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
 # When the PORT environment variable is defined, the default bind is ['0.0.0.0:$PORT']
-CMD ["gunicorn", "--workers 1", "--worker-class", "uvicorn.workers.UvicornWorker", "--threads", "1", "app.main:app", "--timeout", "0" ]
+CMD ["gunicorn", "--workers", "1", "--worker-class", "uvicorn.workers.UvicornWorker", "--threads", "1", "--timeout", "0", "app.main:app"]


### PR DESCRIPTION
PR does some QoL changes

* adds `--no-cache-dir` for safety
* Adds `SHELL` to set `bash -c` instead of inlining it within the `RUN`
* Updates CMD to use `gunicorn` as PID 1. As we learned, gunicorn handle being the init process well
* Removes `--bind :$PORT` [since we can use the env var `PORT`](https://docs.gunicorn.org/en/stable/settings.html#server-socket)