### PR TITLE
optional creation at firebase endpoint

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -97,7 +97,9 @@ def secure_user_endpoint(
     else:
         user = crud.user.get_by_account_email(session, email)
         if not user:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No account")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="No account"
+            )
 
     if was_created:
         crud.event.create(


### PR DESCRIPTION
Makes the creation of users via the `/auth/firebase` endpoint optional