### PR TITLE
API to create work with editions

### DIFF
--- a/app/api/editions.py
+++ b/app/api/editions.py
@@ -1,15 +1,15 @@
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
-from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+from starlette import status
 from structlog import get_logger
 
-from starlette import status
 from app import crud
 from app.api.common.pagination import PaginatedQueryParams
-from app.api.dependencies.security import get_current_active_user_or_service_account
 from app.api.dependencies.editions import get_edition_from_isbn
+from app.api.dependencies.security import get_current_active_user_or_service_account
 from app.db.session import get_session
 from app.models import Edition
 from app.schemas.edition import (

--- a/app/crud/edition.py
+++ b/app/crud/edition.py
@@ -1,12 +1,10 @@
 from datetime import datetime
-from typing import Any, Dict, List
-from fastapi import Depends
+from typing import Any, List
 
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Query, Session
 from structlog import get_logger
-from app.crud.base import UpdateSchemaType
 
 import app.services.editions as editions_service
 from app import crud
@@ -17,7 +15,7 @@ from app.crud.illustrator import illustrator as crud_illustrator
 from app.crud.work import work as crud_work
 from app.models import Edition, Illustrator, Work
 from app.models.work import WorkType
-from app.schemas.edition import EditionCreateIn, EditionDetail, EditionUpdateIn
+from app.schemas.edition import EditionCreateIn, EditionUpdateIn
 from app.schemas.work import WorkCreateIn
 
 logger = get_logger()

--- a/app/schemas/author.py
+++ b/app/schemas/author.py
@@ -9,7 +9,7 @@ class ContributorBase(BaseModel):
 
 
 class AuthorBrief(ContributorBase):
-    id: int
+    id: str
 
     class Config:
         orm_mode = True

--- a/app/schemas/edition.py
+++ b/app/schemas/edition.py
@@ -3,7 +3,6 @@ from enum import Enum
 from typing import Optional
 
 from pydantic import AnyHttpUrl, BaseModel, validator
-from app.models.illustrator import Illustrator
 
 from app.schemas.author import AuthorBrief, AuthorCreateIn, ContributorBase
 from app.schemas.illustrator import IllustratorBrief, IllustratorCreateIn

--- a/app/schemas/illustrator.py
+++ b/app/schemas/illustrator.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from pydantic import BaseModel
-
 from app.schemas.author import ContributorBase
 
 

--- a/app/schemas/work.py
+++ b/app/schemas/work.py
@@ -18,7 +18,7 @@ class WorkInfo(BaseModel):
 
 
 class WorkBrief(BaseModel):
-    id: int
+    id: str
     type: Optional[WorkType]
 
     leading_article: str | None
@@ -57,6 +57,16 @@ class WorkCreateIn(BaseModel):
     series_name: Optional[str]
     series_number: Optional[int]
 
+    info: Optional[dict]
+
+
+class WorkCreateWithEditionsIn(BaseModel):
+    type: WorkType = WorkType.BOOK
+    leading_article: Optional[str]
+    title: str
+    subtitle: Optional[str]
+    authors: List[AuthorCreateIn | int]
+    editions: list[str]
     info: Optional[dict]
 
 

--- a/app/tests/integration/test_editions_api.py
+++ b/app/tests/integration/test_editions_api.py
@@ -1,4 +1,5 @@
 from starlette import status
+
 from app.models.edition import Edition
 from app.schemas.edition import EditionUpdateIn
 

--- a/app/tests/integration/test_work_api.py
+++ b/app/tests/integration/test_work_api.py
@@ -3,6 +3,7 @@ import time
 from starlette import status
 
 from app import crud
+from app.models import Edition
 
 
 def test_backend_service_account_can_list_works(
@@ -15,7 +16,7 @@ def test_backend_service_account_can_list_works(
 def test_backend_service_account_can_get_detail_on_specific_works(
     client, backend_service_account_headers, works_list
 ):
-    for work in works_list:
+    for work in works_list[:3]:
         response = client.get(
             f"v1/work/{work.id}", headers=backend_service_account_headers
         )
@@ -35,6 +36,20 @@ def test_backend_service_account_can_get_edit_detail_on_specific_work(
     )
     work_data = response.json()
     assert work_data["title"] == "New Title"
+
+
+def test_backend_service_account_can_create_empty_work(
+    client, backend_service_account_headers, works_list
+):
+
+    response = client.post(
+        f"v1/work",
+        json={"title": "Test Work", "authors": [], "editions": []},
+        headers=backend_service_account_headers,
+    )
+    work_data = response.json()
+    assert "id" in work_data
+    assert work_data["title"] == "Test Work"
 
 
 def test_backend_service_account_can_label_work(
@@ -102,3 +117,99 @@ def test_student_account_not_allowed_to_edit_work(
         headers=test_student_user_account_headers,
     )
     assert response.status_code == 403
+
+
+def test_move_edition_to_new_work(client, backend_service_account_headers, works_list):
+    original_work = works_list[0]
+    test_edition: Edition = original_work.editions[0]
+
+    response = client.post(
+        f"v1/work",
+        json={
+            "title": "New Test Work",
+            "authors": [
+                {
+                    "first_name": original_work.authors[0].first_name,
+                    "last_name": original_work.authors[0].last_name,
+                },
+                # Or by Author ID:
+                # original_work.authors[0].id
+            ],
+            "editions": [test_edition.isbn],
+        },
+        headers=backend_service_account_headers,
+    )
+    response.raise_for_status()
+    work_data = response.json()
+    assert "id" in work_data
+    assert work_data["title"] == "New Test Work"
+
+    response = client.get(
+        f"v1/edition/{test_edition.isbn}",
+        headers=backend_service_account_headers,
+    )
+    edition_data = response.json()
+    assert edition_data["work_id"] == work_data["id"]
+
+
+def test_move_edition_to_new_work_with_existing_author(
+    client, backend_service_account_headers, works_list
+):
+    original_work = works_list[0]
+    test_edition: Edition = original_work.editions[0]
+
+    response = client.post(
+        f"v1/work",
+        json={
+            "title": "New Test Work",
+            "authors": [
+                # {"first_name": original_work.authors[0].first_name, "last_name": original_work.authors[0].last_name},
+                # Or by Author ID:
+                original_work.authors[0].id
+            ],
+            "editions": [test_edition.isbn],
+        },
+        headers=backend_service_account_headers,
+    )
+    work_data = response.json()
+    assert "id" in work_data
+    assert work_data["title"] == "New Test Work"
+    assert work_data["authors"][0]["id"] == str(
+        original_work.authors[0].id
+    ), "Author ID doesn't match"
+
+    response = client.get(
+        f"v1/edition/{test_edition.isbn}",
+        headers=backend_service_account_headers,
+    )
+    edition_data = response.json()
+    assert edition_data["work_id"] == work_data["id"]
+
+
+def test_move_edition_to_existing_work(
+    client, backend_service_account_headers, works_list
+):
+    original_work = works_list[0]
+    new_work = works_list[1]
+
+    test_edition: Edition = original_work.editions[0]
+
+    response = client.patch(
+        f"v1/edition/{test_edition.isbn}",
+        json={
+            "work_id": new_work.id,
+        },
+        headers=backend_service_account_headers,
+    )
+    data = response.json()
+    assert data["work_id"] == str(new_work.id), "work id doesn't match"
+
+    # Confirm the edition has changed
+    response = client.get(
+        f"v1/edition/{test_edition.isbn}",
+        headers=backend_service_account_headers,
+    )
+    edition_data = response.json()
+    assert edition_data["work_id"] == str(
+        new_work.id
+    ), "Edition's work id hasn't updated"


### PR DESCRIPTION
Allows an admin or educator to create a new work with new or existing editions and authors.

Closes WRI-347, required to fully realize the edition/work editing admin interface.