### PR TITLE
Add 'special lists' validator/fetcher for Readers

### DIFF
--- a/app/schemas/users/reader.py
+++ b/app/schemas/users/reader.py
@@ -44,10 +44,12 @@ class ReaderDetail(ReaderBrief, UserDetail):
         output = {}
         # get the first booklist matching each required name (with null safeties)
         output["read_now"] = next(
-            [list for list in lists if list.name == "Books To Read Now"] or [], None
+            iter([list for list in lists if list.name == "Books To Read Now"] or []),
+            None,
         )
         output["read_next"] = next(
-            [list for list in lists if list.name == "Books To Read Next"] or [], None
+            iter([list for list in lists if list.name == "Books To Read Next"] or []),
+            None,
         )
         return output
 
@@ -57,10 +59,11 @@ class ReaderDetail(ReaderBrief, UserDetail):
         output = {}
         # get the first booklist matching each required name (with null safeties)
         output["read_books"] = next(
-            [list for list in lists if list.name == "Books I've Read"] or [], None
+            iter([list for list in lists if list.name == "Books I've Read"] or []), None
         )
         output["favourite_books"] = next(
-            [list for list in lists if list.name == "My Favourite Books"] or [], None
+            iter([list for list in lists if list.name == "My Favourite Books"] or []),
+            None,
         )
         return output
 


### PR DESCRIPTION
Much like the `reading_path` lists such as `Books to Read Now/Next`, two new lists need to be easily fetchable for a reader: `My Favourite Books` and `Books I've Read`.
This PR simply introduces this `special_lists` output by following the same pattern as the `reading_path`.

**Why is this needed?**
There are a number of booklists belonging to a reader that are considered non-arbitrary, these being new additions.
The Huey Books dashboard for a child contains special components for the reading path booklists, and will soon contain similarly special components for read and favourited booklists - which need to be fetched strongly