### PR TITLE
Refactor acls and permissions to use inheritance

### DIFF
--- a/app/api/dependencies/security.py
+++ b/app/api/dependencies/security.py
@@ -208,49 +208,11 @@ def get_active_principals(
     if maybe_user is not None and maybe_user.is_active:
         user = maybe_user
         principals.append(Authenticated)
-
-        match user.type:
-            case UserAccountType.WRIVETED:
-                principals.append("role:admin")
-
-            case UserAccountType.EDUCATOR:
-                principals.append("role:educator")
-                principals.append("role:school")
-                principals.append(f"school:{user.school_id}")
-                principals.append(f"educator:{user.school_id}")
-
-            case UserAccountType.SCHOOL_ADMIN:
-                principals.append("role:educator")
-                principals.append("role:school")
-                principals.append(f"school:{user.school_id}")
-                principals.append(f"educator:{user.school_id}")
-                principals.append(f"schooladmin:{user.school_id}")
-
-            case UserAccountType.STUDENT:
-                principals.append("role:reader")
-                principals.append("role:student")
-                principals.append("role:school")
-                principals.append(f"school:{user.school_id}")
-                principals.append(f"student:{user.school_id}")
-                if user.parent:
-                    principals.append(f"child:{user.parent_id}")
-
-            case UserAccountType.PUBLIC:
-                principals.append("role:reader")
-                if user.parent:
-                    principals.append(f"child:{user.parent_id}")
-
-            case UserAccountType.PARENT:
-                principals.append("role:parent")
-                for child in user.children:
-                    principals.append(f"parent:{child.id}")
-
-            case UserAccountType.SUPPORTER:
-                for reader in user.readers:
-                    principals.append(f"supporter:{reader.id}")
-
-        # All users have a user specific role:
-        principals.append(f"user:{user.id}")
+        # since the user type being returned from crud is dynamic based on type,
+        # we can call the get_principals method on the user object to get a cascading
+        # list of principals.
+        # i.e. a student will have calculated principals of a user, a reader, and a student
+        principals.extend(user.get_principals())
 
     elif maybe_service_account is not None and maybe_service_account.is_active:
         service_account = maybe_service_account

--- a/app/models/educator.py
+++ b/app/models/educator.py
@@ -38,6 +38,13 @@ class Educator(User):
         active = "Active" if self.is_active else "Inactive"
         return f"<Educator {self.name} - {self.school} - {active}>"
 
+    def get_principals(self):
+        principals = super().get_principals()
+
+        principals.extend(["role:educator", f"educator:{self.school_id}"])
+
+        return principals
+
     def __acl__(self):
         """defines who can do what to the instance
         the function returns a list containing tuples in the form of
@@ -46,9 +53,13 @@ class Educator(User):
         automatically denied.
         (Deny, Everyone, All) is automatically appended at the end.
         """
-        return [
-            (Allow, f"user:{self.id}", All),
-            (Allow, "role:admin", All),
-            (Allow, f"schooladmin:{self.school_id}", All),
-            (Allow, f"educator:{self.school_id}", "read"),
-        ]
+        acl = super().__acl__()
+
+        acl.extend(
+            [
+                (Allow, f"schooladmin:{self.school_id}", All),
+                (Allow, f"educator:{self.school_id}", "read"),
+            ]
+        )
+
+        return acl

--- a/app/models/public_reader.py
+++ b/app/models/public_reader.py
@@ -32,6 +32,10 @@ class PublicReader(Reader):
         active = "Active" if self.is_active else "Inactive"
         return f"<Public Reader {self.name} - {active}>"
 
+    def get_principals(self):
+        principals = super().get_principals()
+        return principals
+
     def __acl__(self):
         """defines who can do what to the instance
         the function returns a list containing tuples in the form of
@@ -40,8 +44,5 @@ class PublicReader(Reader):
         automatically denied.
         (Deny, Everyone, All) is automatically appended at the end.
         """
-        return [
-            (Allow, f"user:{self.id}", All),
-            (Allow, "role:admin", All),
-            (Allow, f"parent:{self.id}", All),
-        ]
+        acl = super().__acl__()
+        return acl

--- a/app/models/school_admin.py
+++ b/app/models/school_admin.py
@@ -35,6 +35,11 @@ class SchoolAdmin(Educator):
         active = "Active" if self.is_active else "Inactive"
         return f"<School Admin {self.name} - {self.school} - {active}>"
 
+    def get_principals(self):
+        principals = super().get_principals()
+        principals.append(f"schooladmin:{self.school_id}")
+        return principals
+
     def __acl__(self):
         """defines who can do what to the instance
         the function returns a list containing tuples in the form of
@@ -43,9 +48,11 @@ class SchoolAdmin(Educator):
         automatically denied.
         (Deny, Everyone, All) is automatically appended at the end.
         """
-        return [
-            (Allow, f"user:{self.id}", All),
-            (Allow, "role:admin", All),
-            (Allow, f"educator:{self.school_id}", "read"),
-            (Allow, f"schooladmin:{self.school_id}", All),
-        ]
+        acl = super().__acl__()
+        acl.extend(
+            [
+                (Allow, f"educator:{self.school_id}", "read"),
+                (Allow, f"schooladmin:{self.school_id}", All),
+            ]
+        )
+        return acl

--- a/app/models/student.py
+++ b/app/models/student.py
@@ -62,6 +62,18 @@ class Student(Reader):
         active = "Active" if self.is_active else "Inactive"
         return f"<Student {self.username} - {self.school} - {active}>"
 
+    def get_principals(self):
+        principals = super().get_principals()
+
+        principals.extend(
+            [
+                "role:student",
+                f"student:{self.school_id}",
+            ]
+        )
+
+        return principals
+
     def __acl__(self):
         """defines who can do what to the instance
         the function returns a list containing tuples in the form of
@@ -70,10 +82,13 @@ class Student(Reader):
         automatically denied.
         (Deny, Everyone, All) is automatically appended at the end.
         """
-        return [
-            (Allow, f"user:{self.id}", All),
-            (Allow, "role:admin", All),
-            (Allow, f"parent:{self.id}", All),
-            (Allow, f"educator:{self.school_id}", All),
-            (Allow, f"schooladmin:{self.school_id}", All),
-        ]
+        acl = super().__acl__()
+
+        acl.extend(
+            [
+                (Allow, f"educator:{self.school_id}", "all-school"),
+                (Allow, f"schooladmin:{self.school_id}", "all-school"),
+            ]
+        )
+
+        return acl

--- a/app/models/supporter.py
+++ b/app/models/supporter.py
@@ -1,4 +1,3 @@
-from fastapi_permissions import All, Allow
 from sqlalchemy import JSON, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
@@ -9,7 +8,7 @@ from app.models.user import User, UserAccountType
 
 class Supporter(User):
     """
-    A concrete Supporter of a Reader.
+    A user who supports and encourages reader(s).
     """
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -37,12 +36,6 @@ class Supporter(User):
         automatically denied.
         (Deny, Everyone, All) is automatically appended at the end.
         """
-        roles = [
-            (Allow, f"user:{self.id}", All),
-            (Allow, f"user:{self.parent_id}", "All"),
-            (Allow, "role:admin", All),
-        ]
-        if self.parent_id:
-            roles.append((Allow, f"user:{self.parent_id}", All))
+        acls = super().__acl__()
 
-        return roles
+        return acls

--- a/app/models/supporter_reader_association.py
+++ b/app/models/supporter_reader_association.py
@@ -11,13 +11,23 @@ class SupporterReaderAssociation(Base):
         ForeignKey("users.id", name="fk_supporter_reader_assoc_supporter_id"),
         primary_key=True,
     )
-    supporter = relationship("User", viewonly=True, foreign_keys=[supporter_id])
+    supporter = relationship(
+        "User",
+        viewonly=True,
+        back_populates="supportee_associations",
+        foreign_keys=[supporter_id],
+    )
 
     reader_id = mapped_column(
         "reader_id",
         ForeignKey("readers.id", name="fk_supporter_reader_assoc_reader_id"),
         primary_key=True,
     )
-    reader = relationship("Reader", viewonly=True, foreign_keys=[reader_id])
+    reader = relationship(
+        "Reader",
+        viewonly=True,
+        back_populates="supporter_associations",
+        foreign_keys=[reader_id],
+    )
 
     is_active = mapped_column(Boolean(), nullable=False, default=True)

--- a/app/models/wriveted_admin.py
+++ b/app/models/wriveted_admin.py
@@ -33,6 +33,11 @@ class WrivetedAdmin(User):
         active = "Active" if self.is_active else "Inactive"
         return f"<Wriveted Admin {self.name} - {active}>"
 
+    def get_principals(self):
+        principals = super().get_principals()
+        principals.append("role:admin")
+        return principals
+
     def __acl__(self):
         """defines who can do what to the instance
         the function returns a list containing tuples in the form of
@@ -41,7 +46,5 @@ class WrivetedAdmin(User):
         automatically denied.
         (Deny, Everyone, All) is automatically appended at the end.
         """
-        return [
-            (Allow, f"user:{self.id}", All),
-            (Allow, "role:admin", All),
-        ]
+        acl = super().__acl__()
+        return acl


### PR DESCRIPTION
While making changes to allow any user type to become a supporter of a reader, I began to modify the `get_active_principals()` function, and noticed that my changes would have uglied up an already long function quite a bit.
I had to touch on multiple levels of our User hierarchy, and a match case on the user type enum doesn't fit the dimensionality of our inheritance: lots of permission-based logic was duplicated in Educator/School admin, Reader/Student, etc.

Decided to restructure the layer to better fit with our models, and make future additions or changes easier.

Additionally makes some smaller changes we've discussed: removing the school: principal for example.

Apologies for the contaminated diff, there are some unrelated parts (I was pretty deep into feedback changes when I decided to do this).

Is this a bad approach?