### PR TITLE
Wip: arbitrary ordering for bulk get endpoints

### DIFF
--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -107,6 +107,8 @@ async def get_collection_items(
         read_status=read_status,
         skip=pagination.skip,
         limit=pagination.limit,
+        order_by=pagination.order_by,
+        order_direction=pagination.order_direction,
     )
 
     logger.debug(

--- a/app/api/common/pagination.py
+++ b/app/api/common/pagination.py
@@ -1,17 +1,40 @@
 from fastapi import Query
 
 
+class PaginationOrderingError(Exception):
+    """Raised when an invalid pagination ordering is specified"""
+
+
 class PaginatedQueryParams:
     def __init__(
         self,
         skip: int = Query(0, description="Skip this many items"),
         limit: int = Query(100, description="Maximum number of items to return"),
+        order_by: str = Query(None, description="Column name to order by"),
+        order_by_table: str = Query(
+            None,
+            description="Optional table name containing the column to order by, for the case of joined loads",
+        ),
+        order_direction: str = Query(
+            "asc",
+            description="Order direction. Ignored if no order_by is specified",
+            regex="(?i)^(asc|desc)$",
+        ),
     ):
         self.skip = skip
         self.limit = limit
+        self.order_by = order_by
+        self.order_by_table = order_by_table
+        self.order_direction = order_direction if order_by else None
 
     def __repr__(self):
-        return f"<Pagination skip={self.skip}, limit={self.limit}>"
+        return f"<Pagination skip={self.skip}, limit={self.limit}, order_by={self.order_by}, order_by_table={self.order_by_table}, order_direction={self.order_direction}>"
 
     def to_dict(self):
-        return {"skip": self.skip, "limit": self.limit}
+        return {
+            "skip": self.skip,
+            "limit": self.limit,
+            "order_by": self.order_by,
+            "order_by_table": self.order_by_table,
+            "order_direction": self.order_direction,
+        }

--- a/app/crud/collection.py
+++ b/app/crud/collection.py
@@ -422,6 +422,8 @@ class CRUDCollection(CRUDBase[Collection, Any, Any]):
         read_status: Optional[CollectionItemReadStatus] = None,
         skip: int = 0,
         limit: int = 1000,
+        order_by: str = None,
+        order_direction: str = None,
     ):
         statement = (
             select(CollectionItem)
@@ -483,7 +485,13 @@ class CRUDCollection(CRUDBase[Collection, Any, Any]):
         aliased_model = aliased(CollectionItem, cte)
         matching_count = db.scalar(select(func.count(aliased_model.id)))
 
-        paginated_items_query = self.apply_pagination(statement, skip=skip, limit=limit)
+        paginated_items_query = self.apply_pagination(
+            statement,
+            skip=skip,
+            limit=limit,
+            order_by=order_by,
+            order_direction=order_direction,
+        )
 
         return matching_count, db.scalars(paginated_items_query).all()
 

--- a/app/crud/edition.py
+++ b/app/crud/edition.py
@@ -37,10 +37,8 @@ class CRUDEdition(CRUDBase[Edition, EditionCreateIn, EditionUpdateIn]):
 
         return select(Edition).where(Edition.isbn == cleaned_isbn)
 
-    def get_multi_query(
-        self, db: Session, ids: List[Any], *, order_by=None
-    ) -> Select[Edition]:
-        return self.get_all_query(db, order_by=order_by).where(
+    def get_multi_query(self, db: Session, ids: List[Any]) -> Select[Edition]:
+        return self.get_all_query(db).where(
             Edition.isbn.in_(editions_service.clean_isbns(ids))
         )
 

--- a/app/tests/integration/test_work_api.py
+++ b/app/tests/integration/test_work_api.py
@@ -236,3 +236,59 @@ def test_move_edition_to_existing_work(
     assert edition_data["work_id"] == str(
         new_work.id
     ), "Edition's work id hasn't updated"
+
+
+def test_arbitrary_works_ordering(client, backend_service_account_headers, works_list):
+    title_order_asc_response = client.get(
+        "v1/works",
+        headers=backend_service_account_headers,
+        params={"order_by": "title", "order_direction": "asc", "limit": 30},
+    )
+    title_order_asc_data = title_order_asc_response.json()
+    assert (
+        sorted(title_order_asc_data, key=lambda x: x["title"]) == title_order_asc_data
+    )
+
+    title_order_desc_response = client.get(
+        "v1/works",
+        headers=backend_service_account_headers,
+        params={"order_by": "title", "order_direction": "desc", "limit": 30},
+    )
+    title_order_desc_data = title_order_desc_response.json()
+    assert (
+        sorted(title_order_desc_data, key=lambda x: x["title"], reverse=True)
+        == title_order_desc_data
+    )
+
+    id_order_asc_response = client.get(
+        "v1/works",
+        headers=backend_service_account_headers,
+        params={"order_by": "id", "order_direction": "asc", "limit": 30},
+    )
+    id_order_asc_data = id_order_asc_response.json()
+    assert sorted(id_order_asc_data, key=lambda x: int(x["id"])) == id_order_asc_data
+
+    id_order_desc_response = client.get(
+        "v1/works",
+        headers=backend_service_account_headers,
+        params={"order_by": "id", "order_direction": "desc", "limit": 30},
+    )
+    id_order_desc_data = id_order_desc_response.json()
+    assert (
+        sorted(id_order_desc_data, key=lambda x: int(x["id"]), reverse=True)
+        == id_order_desc_data
+    )
+
+    nonexisting_order_by_response = client.get(
+        "v1/works",
+        headers=backend_service_account_headers,
+        params={"order_by": "invalid", "order_direction": "asc", "limit": 30},
+    )
+    assert nonexisting_order_by_response.status_code == 400
+
+    existing_but_invalid_order_by_response = client.get(
+        "v1/works",
+        headers=backend_service_account_headers,
+        params={"order_by": "info", "order_direction": "asc", "limit": 30},
+    )
+    assert existing_but_invalid_order_by_response.status_code == 400


### PR DESCRIPTION
Part of a daisy chain to ultimately have a child's "want to read" list show the most recently added books first (among other things).

https://user-images.githubusercontent.com/97575656/222452516-9f6dd5c9-03b6-4ff6-9093-01ff489c6f39.mp4





Current issues: 
* Ordering on joined tables succeeds in terms of generating a query (raw sql output is sound), but converting the query to scalars results in no such ordering. Example: `/list/{id}` endpoint when pagination = `{"order_by": "title", "order_by_table": "works"}`
https://github.com/Wriveted/wriveted-api/blob/6fd882d01b0736fba6290e78f2b67a61b2ea6084/app/api/booklists.py#L246
