### PR TITLE
use python:3.11-slim as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-slim
 
 LABEL org.opencontainers.image.source=https://github.com/Wriveted/wriveted-api
 


### PR DESCRIPTION
PR updates the base docker image to use the [slim](https://hub.docker.com/_/python#:~:text=python%3A%3Cversion%3E%2Dslim) variant. AFAIK we don't need the full distro image and packages.

Prior to this PR the image size was `1.3GBs`, with the `slim` image it's now  `551MBs` (both built locally). This should speed up pushing and pulling images, as well as lower the surface area of the image wrt security. Note the first build and push will be slow on the CI since it won't be cached. 