### PR TITLE
replace wget with curl

### DIFF
--- a/.cloudbuild/scripts/database_migrate.sh
+++ b/.cloudbuild/scripts/database_migrate.sh
@@ -13,7 +13,7 @@ proxy_connection_cleanup() {
 trap proxy_connection_cleanup EXIT SIGTERM SIGINT SIGQUIT
 
 echo "Downloading cloud_sql_proxy"
-wget -q "https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64" -O cloud_sql_proxy
+curl -s "https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64" -o cloud_sql_proxy
 chmod +x cloud_sql_proxy
 ./cloud_sql_proxy -instances="${CLOUD_SQL_INSTANCE}=tcp:localhost:${POSTGRES_PORT}" &
 


### PR DESCRIPTION
Tested locally by pulling down `gcr.io/cloud-builders/docker`, and `wget` is not in the `PATH` but `curl` is. I think `curl` is generally safer to assume to exist in images.