### PR TITLE
add curl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,13 @@ ENV PIP_NO_CACHE_DIR=1 \
   VIRTUAL_ENV=/poetry-env \
   PATH="/poetry-env/bin:/opt/poetry/bin:$PATH"
 
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
     curl \
   && apt-get autoremove -y \
-  && apt-get clean
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Poetry
 # hadolint ignore=DL3013


### PR DESCRIPTION
Turns out it's using this image to run `curl` (prior `wget`), since `slim` doesn't have this installed we have to add it. Added as a new layer since it would be easier to cache. Image size is `555MB` (from `551MBs`)