### PR TITLE
download and run cloud_sql_proxy in the home directory

### DIFF
--- a/.cloudbuild/scripts/database_migrate.sh
+++ b/.cloudbuild/scripts/database_migrate.sh
@@ -13,9 +13,9 @@ proxy_connection_cleanup() {
 trap proxy_connection_cleanup EXIT SIGTERM SIGINT SIGQUIT
 
 echo "Downloading cloud_sql_proxy"
-curl -s "https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64" -o cloud_sql_proxy
-chmod +x cloud_sql_proxy
-./cloud_sql_proxy -instances="${CLOUD_SQL_INSTANCE}=tcp:localhost:${POSTGRES_PORT}" &
+curl -s "https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64" -o "${HOME}/cloud_sql_proxy"
+chmod +x "${HOME}/cloud_sql_proxy"
+"${HOME}/cloud_sql_proxy" -instances="${CLOUD_SQL_INSTANCE}=tcp:localhost:${POSTGRES_PORT}" &
 
 echo "Running migration"
 export SQLALCHEMY_DATABASE_URI="postgresql://postgres:${POSTGRESQL_PASSWORD}@localhost/postgres"


### PR DESCRIPTION
The CloudBuild DB migration step fails because it attempts to download the `cloud_sql_proxy` binary to `/app`  which isn't writable. This PR fixes it by downloading and running it from `$HOME`