### PR TITLE
Self-service school onboarding endpoint

### DIFF
--- a/app/api/external_api_router.py
+++ b/app/api/external_api_router.py
@@ -18,6 +18,7 @@ from app.api.events import router as events_router
 from app.api.hydration import router as hydration_router
 from app.api.illustrators import router as illustrator_router
 from app.api.labelset import router as labelset_router
+from app.api.onboarding import router as onboarding_router
 from app.api.recommendations import router as recommendations_router
 from app.api.schools import public_router as school_router_public
 from app.api.schools import router as school_router
@@ -51,6 +52,7 @@ api_router.include_router(events_router)
 api_router.include_router(hydration_router)
 api_router.include_router(illustrator_router)
 api_router.include_router(labelset_router)
+api_router.include_router(onboarding_router)
 api_router.include_router(school_router)
 api_router.include_router(school_router_public)
 api_router.include_router(service_account_router)

--- a/app/api/onboarding.py
+++ b/app/api/onboarding.py
@@ -1,0 +1,245 @@
+"""Self-service onboarding endpoints for schools and families."""
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, EmailStr
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from starlette import status
+from structlog import get_logger
+
+from app.api.dependencies.async_db_dep import DBSessionDep
+from app.api.dependencies.security import get_current_active_user
+from app.models import School, SchoolAdmin, SchoolState
+from app.models.school import SchoolBookbotType
+from app.models.user import User, UserAccountType
+from app.repositories.event_repository import event_repository
+from app.services.experiments import get_experiments
+
+logger = get_logger()
+
+router = APIRouter(
+    prefix="/onboarding",
+    tags=["Onboarding"],
+)
+
+
+class SchoolOnboardingRequest(BaseModel):
+    # Option A: select existing school
+    school_wriveted_id: Optional[UUID] = None
+
+    # Option B: create new school
+    school_name: Optional[str] = None
+    country_code: Optional[str] = None
+    location: Optional[dict] = None
+
+    # Contact details
+    contact_name: str
+    contact_email: EmailStr
+    contact_role: str
+    contact_phone: Optional[str] = None
+    student_count_estimate: Optional[int] = None
+    message: Optional[str] = None
+
+
+class SchoolOnboardingResponse(BaseModel):
+    school_wriveted_id: UUID
+    school_name: str
+    school_state: SchoolState
+    message: str
+
+
+@router.post("/school", response_model=SchoolOnboardingResponse)
+async def onboard_school(
+    request: SchoolOnboardingRequest,
+    db: DBSessionDep,
+    current_user: User = Depends(get_current_active_user),
+):
+    """Self-service school onboarding.
+
+    Creates or selects a school, promotes the user to SchoolAdmin,
+    binds them as the school's administrator, and sets the school
+    to PENDING for admin review.
+    """
+    # Resolve or create the school
+    if request.school_wriveted_id:
+        result = await db.execute(
+            select(School).where(
+                School.wriveted_identifier == request.school_wriveted_id
+            )
+        )
+        school = result.scalars().first()
+        if school is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="School not found",
+            )
+        if school.state == SchoolState.ACTIVE:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="This school is already active. Contact us if you need access.",
+            )
+    else:
+        if not request.school_name or not request.country_code:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="school_name and country_code are required when creating a new school",
+            )
+        try:
+            school = School(
+                name=request.school_name,
+                country_code=request.country_code,
+                state=SchoolState.PENDING,
+                bookbot_type=SchoolBookbotType.HUEY_BOOKS,
+                info={
+                    "location": request.location or {},
+                    "experiments": get_experiments({}),
+                },
+            )
+            db.add(school)
+            await db.flush()
+        except IntegrityError:
+            await db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A school with this name already exists in this country",
+            )
+
+    # Store onboarding contact info
+    onboarding_info = {
+        "onboarding": {
+            "contact_name": request.contact_name,
+            "contact_email": request.contact_email,
+            "contact_role": request.contact_role,
+            "contact_phone": request.contact_phone,
+            "student_count_estimate": request.student_count_estimate,
+            "message": request.message,
+        }
+    }
+    if school.info is None:
+        school.info = onboarding_info
+    else:
+        school.info = {**school.info, **onboarding_info}
+
+    school.state = SchoolState.PENDING
+
+    # Promote user to SchoolAdmin if needed
+    if current_user.type != UserAccountType.SCHOOL_ADMIN:
+        await _promote_to_school_admin(db, current_user, school)
+    else:
+        # Already a SchoolAdmin — just bind to this school
+        current_user.school_id = school.id
+        db.add(current_user)
+
+    # Set the admin relationship on the school
+    result = await db.execute(
+        select(SchoolAdmin).where(SchoolAdmin.id == current_user.id)
+    )
+    school_admin = result.scalars().first()
+    if school_admin:
+        school.admin = school_admin
+
+    await db.flush()
+
+    # Create an event for admin visibility
+    await event_repository.acreate(
+        session=db,
+        title="School onboarding request",
+        description=f"{request.contact_name} ({request.contact_role}) requested onboarding for {school.name}",
+        info={
+            "school_name": school.name,
+            "school_wriveted_id": str(school.wriveted_identifier),
+            "contact_name": request.contact_name,
+            "contact_email": request.contact_email,
+            "contact_role": request.contact_role,
+            "student_count": request.student_count_estimate,
+        },
+        school=school,
+        commit=False,
+    )
+
+    await db.commit()
+
+    logger.info(
+        "School onboarding completed",
+        school_name=school.name,
+        school_id=str(school.wriveted_identifier),
+        user_email=current_user.email,
+    )
+
+    return SchoolOnboardingResponse(
+        school_wriveted_id=school.wriveted_identifier,
+        school_name=school.name,
+        school_state=school.state,
+        message="Your school is pending review. We'll be in touch shortly!",
+    )
+
+
+async def _promote_to_school_admin(
+    db: DBSessionDep,
+    user: User,
+    school: School,
+) -> None:
+    """Promote a user to SchoolAdmin type, preserving their identity."""
+    user_id = user.id
+
+    logger.info(
+        "Promoting user to SchoolAdmin",
+        user_id=str(user_id),
+        old_type=user.type,
+        school=school.name,
+    )
+
+    # Delete from the current type's table (e.g. public_readers)
+    # The joined-table inheritance means we need to delete the subclass row
+    # then the base user row, then re-insert as SchoolAdmin
+    type_table_map = {
+        UserAccountType.PUBLIC: "public_readers",
+        UserAccountType.STUDENT: "students",
+        UserAccountType.EDUCATOR: "educators",
+        UserAccountType.PARENT: "parents",
+        UserAccountType.SUPPORTER: "supporters",
+    }
+
+    subclass_table = type_table_map.get(user.type)
+    if subclass_table:
+        from sqlalchemy import text
+
+        await db.execute(
+            text(f"DELETE FROM {subclass_table} WHERE id = :uid"),
+            {"uid": user_id},
+        )
+
+    # Update the user type and insert the school_admin row
+    await db.execute(
+        text("UPDATE users SET type = :new_type WHERE id = :uid"),
+        {"new_type": UserAccountType.SCHOOL_ADMIN.value, "uid": user_id},
+    )
+
+    # Insert into educators (parent of school_admins in inheritance)
+    try:
+        await db.execute(
+            text(
+                "INSERT INTO educators (id, school_id) VALUES (:uid, :school_id) "
+                "ON CONFLICT (id) DO UPDATE SET school_id = :school_id"
+            ),
+            {"uid": user_id, "school_id": school.id},
+        )
+    except IntegrityError:
+        pass
+
+    # Insert into school_admins
+    try:
+        await db.execute(
+            text(
+                "INSERT INTO school_admins (id) VALUES (:uid) "
+                "ON CONFLICT (id) DO NOTHING"
+            ),
+            {"uid": user_id},
+        )
+    except IntegrityError:
+        pass
+
+    await db.flush()

--- a/app/api/onboarding.py
+++ b/app/api/onboarding.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, EmailStr
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from starlette import status
 from structlog import get_logger
@@ -183,8 +183,6 @@ async def _promote_to_school_admin(
     school: School,
 ) -> None:
     """Promote a user to SchoolAdmin type, preserving their identity."""
-    from sqlalchemy import text
-
     user_id = user.id
 
     logger.info(
@@ -247,3 +245,130 @@ async def _promote_to_school_admin(
         pass
 
     await db.flush()
+
+
+# ── Family onboarding ─────────────────────────────────────────────────
+
+
+class ChildInfo(BaseModel):
+    name: str
+    age: Optional[int] = None
+    reading_ability: Optional[str] = None
+    interests: Optional[list[str]] = None
+
+
+class FamilyOnboardingRequest(BaseModel):
+    parent_name: str
+    children: list[ChildInfo]
+
+
+class FamilyOnboardingResponse(BaseModel):
+    parent_id: UUID
+    children_created: int
+    message: str
+
+
+@router.post("/family", response_model=FamilyOnboardingResponse)
+async def onboard_family(
+    request: FamilyOnboardingRequest,
+    db: DBSessionDep,
+    current_user: User = Depends(get_current_active_user),
+):
+    """Self-service family onboarding.
+
+    Promotes the authenticated user to Parent type and creates
+    child reader accounts linked to them.
+    """
+    from app.models.public_reader import PublicReader
+
+    user_id = current_user.id
+
+    # Promote to Parent if needed
+    if current_user.type != UserAccountType.PARENT:
+        if current_user.type == UserAccountType.SCHOOL_ADMIN:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="School admin accounts cannot be converted to parent accounts.",
+            )
+
+        safe_type_table_map = {
+            UserAccountType.PUBLIC: "public_readers",
+            UserAccountType.STUDENT: "students",
+            UserAccountType.SUPPORTER: "supporters",
+        }
+        subclass_table = safe_type_table_map.get(current_user.type)
+        if subclass_table:
+            await db.execute(
+                text(f"DELETE FROM {subclass_table} WHERE id = :uid"),
+                {"uid": user_id},
+            )
+
+        # Also remove from readers if present (PUBLIC/STUDENT inherit from Reader)
+        await db.execute(
+            text("DELETE FROM readers WHERE id = :uid"),
+            {"uid": user_id},
+        )
+
+        await db.execute(
+            text("UPDATE users SET type = :new_type, name = :name WHERE id = :uid"),
+            {
+                "new_type": UserAccountType.PARENT.value.upper(),
+                "name": request.parent_name,
+                "uid": user_id,
+            },
+        )
+
+        # Insert into parents table
+        try:
+            await db.execute(
+                text(
+                    "INSERT INTO parents (id) VALUES (:uid) ON CONFLICT (id) DO NOTHING"
+                ),
+                {"uid": user_id},
+            )
+        except IntegrityError:
+            pass
+
+        await db.flush()
+
+    # Create child readers
+    children_created = 0
+    for child in request.children:
+        child_reader = PublicReader(
+            name=child.name,
+            first_name=child.name,
+            parent_id=user_id,
+            huey_attributes={
+                "age": child.age,
+                "reading_ability": child.reading_ability,
+                "interests": child.interests,
+            },
+        )
+        db.add(child_reader)
+        children_created += 1
+
+    # Create event
+    await event_repository.acreate(
+        session=db,
+        title="Family onboarding",
+        description=f"{request.parent_name} signed up with {children_created} child(ren)",
+        info={
+            "parent_name": request.parent_name,
+            "children": [c.model_dump() for c in request.children],
+        },
+        commit=False,
+    )
+
+    await db.commit()
+
+    logger.info(
+        "Family onboarding completed",
+        user_id=str(user_id),
+        children=children_created,
+    )
+
+    return FamilyOnboardingResponse(
+        parent_id=user_id,
+        children_created=children_created,
+        message=f"Welcome! {children_created} reader profile(s) created.",
+    )

--- a/app/api/onboarding.py
+++ b/app/api/onboarding.py
@@ -4,11 +4,12 @@ from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field, StringConstraints
 from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from starlette import status
 from structlog import get_logger
+from typing_extensions import Annotated
 
 from app.api.dependencies.async_db_dep import DBSessionDep
 from app.api.dependencies.security import get_current_active_user
@@ -25,23 +26,40 @@ router = APIRouter(
     tags=["Onboarding"],
 )
 
+# Types that can be safely promoted — any other type is rejected
+_PROMOTABLE_TO_SCHOOL_ADMIN = {
+    UserAccountType.PUBLIC,
+    UserAccountType.STUDENT,
+    UserAccountType.SUPPORTER,
+}
+_PROMOTABLE_TO_PARENT = {
+    UserAccountType.PUBLIC,
+    UserAccountType.STUDENT,
+    UserAccountType.SUPPORTER,
+}
+
+
+class SchoolLocationInput(BaseModel):
+    state: Optional[str] = Field(None, max_length=100)
+    postcode: Optional[str] = Field(None, max_length=20)
+    suburb: Optional[str] = Field(None, max_length=200)
+
 
 class SchoolOnboardingRequest(BaseModel):
-    # Option A: select existing school
     school_wriveted_id: Optional[UUID] = None
 
-    # Option B: create new school
-    school_name: Optional[str] = None
-    country_code: Optional[str] = None
-    location: Optional[dict] = None
+    school_name: Optional[str] = Field(None, max_length=300)
+    country_code: Optional[
+        Annotated[str, StringConstraints(min_length=3, max_length=3)]
+    ] = None
+    location: Optional[SchoolLocationInput] = None
 
-    # Contact details
-    contact_name: str
+    contact_name: str = Field(max_length=200)
     contact_email: EmailStr
-    contact_role: str
-    contact_phone: Optional[str] = None
-    student_count_estimate: Optional[int] = None
-    message: Optional[str] = None
+    contact_role: str = Field(max_length=100)
+    contact_phone: Optional[str] = Field(None, max_length=50)
+    student_count_estimate: Optional[int] = Field(None, ge=1, le=100000)
+    message: Optional[str] = Field(None, max_length=2000)
 
 
 class SchoolOnboardingResponse(BaseModel):
@@ -81,6 +99,15 @@ async def onboard_school(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="This school is already active. Contact us if you need access.",
             )
+        # Prevent hijacking a school that already has an admin
+        admin_result = await db.execute(
+            select(SchoolAdmin).where(SchoolAdmin.school_id == school.id)
+        )
+        if admin_result.scalars().first() is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="This school already has an administrator. Contact us for access.",
+            )
     else:
         if not request.school_name or not request.country_code:
             raise HTTPException(
@@ -94,7 +121,9 @@ async def onboard_school(
                 state=SchoolState.PENDING,
                 bookbot_type=SchoolBookbotType.HUEY_BOOKS,
                 info={
-                    "location": request.location or {},
+                    "location": request.location.model_dump()
+                    if request.location
+                    else {},
                     "experiments": get_experiments({}),
                 },
             )
@@ -128,26 +157,22 @@ async def onboard_school(
     # Promote user to SchoolAdmin if needed
     if current_user.type != UserAccountType.SCHOOL_ADMIN:
         await _promote_to_school_admin(db, current_user, school)
-    else:
-        # Already a SchoolAdmin — just bind to this school
-        current_user.school_id = school.id
-        db.add(current_user)
 
-    # Set the admin relationship on the school
-    result = await db.execute(
-        select(SchoolAdmin).where(SchoolAdmin.id == current_user.id)
+    # Bind user to school via educators table
+    await db.execute(
+        text(
+            "INSERT INTO educators (id, school_id) VALUES (:uid, :school_id) "
+            "ON CONFLICT (id) DO UPDATE SET school_id = :school_id"
+        ),
+        {"uid": current_user.id, "school_id": school.id},
     )
-    school_admin = result.scalars().first()
-    if school_admin:
-        school.admin = school_admin
-
     await db.flush()
 
     # Create an event for admin visibility
     await event_repository.acreate(
         session=db,
         title="School onboarding request",
-        description=f"{request.contact_name} ({request.contact_role}) requested onboarding for {school.name}",
+        description=f"Onboarding request for {school.name}",
         info={
             "school_name": school.name,
             "school_wriveted_id": str(school.wriveted_identifier),
@@ -183,6 +208,12 @@ async def _promote_to_school_admin(
     school: School,
 ) -> None:
     """Promote a user to SchoolAdmin type, preserving their identity."""
+    if user.type not in _PROMOTABLE_TO_SCHOOL_ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Your account type ({user.type.value}) cannot be converted to school admin. Contact support.",
+        )
+
     user_id = user.id
 
     logger.info(
@@ -192,10 +223,7 @@ async def _promote_to_school_admin(
         school=school.name,
     )
 
-    # Delete from the current type's subclass table.
-    # Parent is excluded — deleting from parents would cascade-fail
-    # due to foreign keys from readers. Parents wanting to become
-    # SchoolAdmins need manual admin intervention.
+    # Delete from the current type's subclass table
     safe_type_table_map = {
         UserAccountType.PUBLIC: "public_readers",
         UserAccountType.STUDENT: "students",
@@ -208,41 +236,35 @@ async def _promote_to_school_admin(
             text(f"DELETE FROM {subclass_table} WHERE id = :uid"),
             {"uid": user_id},
         )
-    elif user.type == UserAccountType.PARENT:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Parent accounts cannot be converted to school admin. Please contact support.",
-        )
 
-    # Update the user type and insert the school_admin row
+    # Also remove from readers if present (PUBLIC/STUDENT inherit from Reader)
+    await db.execute(
+        text("DELETE FROM readers WHERE id = :uid"),
+        {"uid": user_id},
+    )
+
+    # Update the user type
     await db.execute(
         text("UPDATE users SET type = :new_type WHERE id = :uid"),
         {"new_type": UserAccountType.SCHOOL_ADMIN.value.upper(), "uid": user_id},
     )
 
     # Insert into educators (parent of school_admins in inheritance)
-    try:
-        await db.execute(
-            text(
-                "INSERT INTO educators (id, school_id) VALUES (:uid, :school_id) "
-                "ON CONFLICT (id) DO UPDATE SET school_id = :school_id"
-            ),
-            {"uid": user_id, "school_id": school.id},
-        )
-    except IntegrityError:
-        pass
+    await db.execute(
+        text(
+            "INSERT INTO educators (id, school_id) VALUES (:uid, :school_id) "
+            "ON CONFLICT (id) DO UPDATE SET school_id = :school_id"
+        ),
+        {"uid": user_id, "school_id": school.id},
+    )
 
     # Insert into school_admins
-    try:
-        await db.execute(
-            text(
-                "INSERT INTO school_admins (id) VALUES (:uid) "
-                "ON CONFLICT (id) DO NOTHING"
-            ),
-            {"uid": user_id},
-        )
-    except IntegrityError:
-        pass
+    await db.execute(
+        text(
+            "INSERT INTO school_admins (id) VALUES (:uid) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"uid": user_id},
+    )
 
     await db.flush()
 
@@ -251,15 +273,15 @@ async def _promote_to_school_admin(
 
 
 class ChildInfo(BaseModel):
-    name: str
-    age: Optional[int] = None
-    reading_ability: Optional[str] = None
-    interests: Optional[list[str]] = None
+    name: str = Field(max_length=200)
+    age: Optional[int] = Field(None, ge=2, le=18)
+    reading_ability: Optional[str] = Field(None, max_length=50)
+    interests: Optional[list[str]] = Field(None, max_length=20)
 
 
 class FamilyOnboardingRequest(BaseModel):
-    parent_name: str
-    children: list[ChildInfo]
+    parent_name: str = Field(max_length=200)
+    children: list[ChildInfo] = Field(min_length=1, max_length=10)
 
 
 class FamilyOnboardingResponse(BaseModel):
@@ -285,10 +307,10 @@ async def onboard_family(
 
     # Promote to Parent if needed
     if current_user.type != UserAccountType.PARENT:
-        if current_user.type == UserAccountType.SCHOOL_ADMIN:
+        if current_user.type not in _PROMOTABLE_TO_PARENT:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail="School admin accounts cannot be converted to parent accounts.",
+                detail=f"Your account type ({current_user.type.value}) cannot be converted to a parent account. Contact support.",
             )
 
         safe_type_table_map = {
@@ -303,7 +325,7 @@ async def onboard_family(
                 {"uid": user_id},
             )
 
-        # Also remove from readers if present (PUBLIC/STUDENT inherit from Reader)
+        # Also remove from readers if present
         await db.execute(
             text("DELETE FROM readers WHERE id = :uid"),
             {"uid": user_id},
@@ -319,15 +341,10 @@ async def onboard_family(
         )
 
         # Insert into parents table
-        try:
-            await db.execute(
-                text(
-                    "INSERT INTO parents (id) VALUES (:uid) ON CONFLICT (id) DO NOTHING"
-                ),
-                {"uid": user_id},
-            )
-        except IntegrityError:
-            pass
+        await db.execute(
+            text("INSERT INTO parents (id) VALUES (:uid) ON CONFLICT (id) DO NOTHING"),
+            {"uid": user_id},
+        )
 
         await db.flush()
 
@@ -351,7 +368,7 @@ async def onboard_family(
     await event_repository.acreate(
         session=db,
         title="Family onboarding",
-        description=f"{request.parent_name} signed up with {children_created} child(ren)",
+        description=f"Family onboarding with {children_created} child(ren)",
         info={
             "parent_name": request.parent_name,
             "children": [c.model_dump() for c in request.children],

--- a/app/api/onboarding.py
+++ b/app/api/onboarding.py
@@ -215,7 +215,7 @@ async def _promote_to_school_admin(
     # Update the user type and insert the school_admin row
     await db.execute(
         text("UPDATE users SET type = :new_type WHERE id = :uid"),
-        {"new_type": UserAccountType.SCHOOL_ADMIN.value, "uid": user_id},
+        {"new_type": UserAccountType.SCHOOL_ADMIN.value.upper(), "uid": user_id},
     )
 
     # Insert into educators (parent of school_admins in inheritance)

--- a/app/api/onboarding.py
+++ b/app/api/onboarding.py
@@ -183,6 +183,8 @@ async def _promote_to_school_admin(
     school: School,
 ) -> None:
     """Promote a user to SchoolAdmin type, preserving their identity."""
+    from sqlalchemy import text
+
     user_id = user.id
 
     logger.info(
@@ -192,24 +194,26 @@ async def _promote_to_school_admin(
         school=school.name,
     )
 
-    # Delete from the current type's table (e.g. public_readers)
-    # The joined-table inheritance means we need to delete the subclass row
-    # then the base user row, then re-insert as SchoolAdmin
-    type_table_map = {
+    # Delete from the current type's subclass table.
+    # Parent is excluded — deleting from parents would cascade-fail
+    # due to foreign keys from readers. Parents wanting to become
+    # SchoolAdmins need manual admin intervention.
+    safe_type_table_map = {
         UserAccountType.PUBLIC: "public_readers",
         UserAccountType.STUDENT: "students",
-        UserAccountType.EDUCATOR: "educators",
-        UserAccountType.PARENT: "parents",
         UserAccountType.SUPPORTER: "supporters",
     }
 
-    subclass_table = type_table_map.get(user.type)
+    subclass_table = safe_type_table_map.get(user.type)
     if subclass_table:
-        from sqlalchemy import text
-
         await db.execute(
             text(f"DELETE FROM {subclass_table} WHERE id = :uid"),
             {"uid": user_id},
+        )
+    elif user.type == UserAccountType.PARENT:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Parent accounts cannot be converted to school admin. Please contact support.",
         )
 
     # Update the user type and insert the school_admin row

--- a/app/services/internal_api_handlers.py
+++ b/app/services/internal_api_handlers.py
@@ -66,3 +66,47 @@ async def handle_recommend(
         "query": query_parameters,
         "books": [book.model_dump(mode="json") for book in recommended_books],
     }
+
+
+@internal_handler("/v1/onboarding/family")
+async def handle_family_onboarding(
+    db: AsyncSession,
+    body: Dict[str, Any],
+    query_params: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Direct service call for family onboarding from chatflow.
+
+    Since chatflow sessions are anonymous, this creates the child readers
+    without promoting a user. The parent account linkage happens when
+    the user signs in on the frontend and claims the session.
+    """
+    from app.models.public_reader import PublicReader
+
+    children_created = 0
+    for child in body.get("children", []):
+        if not isinstance(child, dict) or not child.get("name"):
+            continue
+        age = child.get("age")
+        if isinstance(age, str):
+            try:
+                age = int(age)
+            except ValueError:
+                age = None
+        reader = PublicReader(
+            name=child["name"],
+            first_name=child["name"],
+            huey_attributes={
+                "age": age,
+                "reading_ability": child.get("reading_ability"),
+            },
+        )
+        db.add(reader)
+        children_created += 1
+
+    if children_created > 0:
+        await db.flush()
+
+    return {
+        "children_created": children_created,
+        "message": f"{children_created} reader profile(s) created.",
+    }

--- a/app/services/internal_api_handlers.py
+++ b/app/services/internal_api_handlers.py
@@ -76,28 +76,38 @@ async def handle_family_onboarding(
 ) -> Dict[str, Any]:
     """Direct service call for family onboarding from chatflow.
 
-    Since chatflow sessions are anonymous, this creates the child readers
-    without promoting a user. The parent account linkage happens when
-    the user signs in on the frontend and claims the session.
+    Creates child reader profiles. Since chatflow sessions are anonymous,
+    these readers are unlinked (no parent_id) until the user signs in
+    and claims them via the authenticated onboarding endpoint.
     """
     from app.models.public_reader import PublicReader
 
+    children = body.get("children", [])
+    if not isinstance(children, list):
+        return {"children_created": 0, "message": "Invalid children data"}
+
+    # Cap at 10 children per request
+    children = children[:10]
+
     children_created = 0
-    for child in body.get("children", []):
+    for child in children:
         if not isinstance(child, dict) or not child.get("name"):
             continue
+        name = str(child["name"])[:200]
         age = child.get("age")
         if isinstance(age, str):
             try:
                 age = int(age)
             except ValueError:
                 age = None
+        if age is not None and (age < 2 or age > 18):
+            age = None
         reader = PublicReader(
-            name=child["name"],
-            first_name=child["name"],
+            name=name,
+            first_name=name,
             huey_attributes={
                 "age": age,
-                "reading_ability": child.get("reading_ability"),
+                "reading_ability": str(child.get("reading_ability", ""))[:50] or None,
             },
         )
         db.add(reader)

--- a/app/tests/integration/test_onboarding.py
+++ b/app/tests/integration/test_onboarding.py
@@ -1,9 +1,71 @@
-"""Integration tests for the self-service school onboarding endpoint."""
+"""Integration tests for the self-service onboarding endpoints."""
 
 import secrets
 
 from app.models import SchoolState
 from app.models.user import UserAccountType
+
+# ── Family onboarding ─────────────────────────────────────────────────
+
+
+def test_onboard_family(client, test_user_account, test_user_account_token):
+    """A public user can become a parent with child readers."""
+    response = client.post(
+        "/v1/onboarding/family",
+        headers={"Authorization": f"Bearer {test_user_account_token}"},
+        json={
+            "parent_name": "Test Parent",
+            "children": [
+                {"name": "Alice", "age": 8, "reading_ability": "TREEHOUSE"},
+                {"name": "Bob", "age": 11},
+            ],
+        },
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["children_created"] == 2
+    assert data["parent_id"] is not None
+
+
+def test_onboard_family_promotes_to_parent(
+    client, session_factory, test_user_account_token
+):
+    """The user's type is promoted from PUBLIC to PARENT."""
+    from app.models.user import User
+    from app.services.security import get_payload_from_access_token
+
+    payload = get_payload_from_access_token(test_user_account_token)
+    user_id = payload.sub.split(":")[-1]
+
+    response = client.post(
+        "/v1/onboarding/family",
+        headers={"Authorization": f"Bearer {test_user_account_token}"},
+        json={
+            "parent_name": "Promoted Parent",
+            "children": [{"name": "Charlie", "age": 6}],
+        },
+    )
+    assert response.status_code == 200
+
+    with session_factory() as fresh_session:
+        user = fresh_session.get(User, user_id)
+        assert user is not None
+        assert user.type == UserAccountType.PARENT
+
+
+def test_onboard_family_unauthenticated(client):
+    """Unauthenticated requests are rejected."""
+    response = client.post(
+        "/v1/onboarding/family",
+        json={
+            "parent_name": "Test",
+            "children": [{"name": "Kid"}],
+        },
+    )
+    assert response.status_code in (401, 403)
+
+
+# ── School onboarding ─────────────────────────────────────────────────
 
 
 def test_onboard_new_school(client, test_user_account, test_user_account_token):

--- a/app/tests/integration/test_onboarding.py
+++ b/app/tests/integration/test_onboarding.py
@@ -156,10 +156,13 @@ def test_onboard_creates_event(
 
 
 def test_onboard_promotes_user_to_school_admin(
-    client, session, test_user_account, test_user_account_token
+    client, session_factory, test_user_account_token
 ):
     """The user's account type is promoted from PUBLIC to SCHOOL_ADMIN."""
-    assert test_user_account.type == UserAccountType.PUBLIC
+    from app.services.security import get_payload_from_access_token
+
+    payload = get_payload_from_access_token(test_user_account_token)
+    user_id = payload.sub.split(":")[-1]
 
     school_name = f"Promotion Test School {secrets.token_hex(4)}"
     response = client.post(
@@ -176,9 +179,10 @@ def test_onboard_promotes_user_to_school_admin(
     )
     assert response.status_code == 200
 
-    # Refresh user from DB
-    session.expire_all()
-    from app.models.user import User
+    # Query in a fresh session to see the promoted type
+    with session_factory() as fresh_session:
+        from app.models.user import User
 
-    user = session.query(User).get(test_user_account.id)
-    assert user.type == UserAccountType.SCHOOL_ADMIN
+        user = fresh_session.query(User).get(user_id)
+        assert user is not None
+        assert user.type == UserAccountType.SCHOOL_ADMIN

--- a/app/tests/integration/test_onboarding.py
+++ b/app/tests/integration/test_onboarding.py
@@ -1,0 +1,184 @@
+"""Integration tests for the self-service school onboarding endpoint."""
+
+import secrets
+
+from app.models import SchoolState
+from app.models.user import UserAccountType
+
+
+def test_onboard_new_school(client, test_user_account, test_user_account_token):
+    """A public user can create a new school and become its admin."""
+    school_name = f"Test Onboarding School {secrets.token_hex(4)}"
+    response = client.post(
+        "/v1/onboarding/school",
+        headers={"Authorization": f"Bearer {test_user_account_token}"},
+        json={
+            "school_name": school_name,
+            "country_code": "ATA",
+            "location": {"state": "TestState", "postcode": "0000"},
+            "contact_name": "Test Teacher",
+            "contact_email": "teacher@test.com",
+            "contact_role": "teacher",
+            "student_count_estimate": 200,
+        },
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["school_name"] == school_name
+    assert data["school_state"] == SchoolState.PENDING.value
+    assert data["school_wriveted_id"] is not None
+
+
+def test_onboard_existing_school(
+    client, session, test_user_account, test_user_account_token
+):
+    """A public user can select an existing inactive school and request onboarding."""
+    from app.models import School
+    from app.services.experiments import get_experiments
+
+    # Create a school directly
+    school = School(
+        name=f"Existing School {secrets.token_hex(4)}",
+        country_code="ATA",
+        state=SchoolState.INACTIVE,
+        info={"location": {"state": "Test", "postcode": "1234"}, "experiments": get_experiments({})},
+    )
+    session.add(school)
+    session.commit()
+    session.refresh(school)
+    wriveted_id = str(school.wriveted_identifier)
+
+    response = client.post(
+        "/v1/onboarding/school",
+        headers={"Authorization": f"Bearer {test_user_account_token}"},
+        json={
+            "school_wriveted_id": wriveted_id,
+            "contact_name": "Test Librarian",
+            "contact_email": "librarian@test.com",
+            "contact_role": "librarian",
+        },
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["school_wriveted_id"] == wriveted_id
+    assert data["school_state"] == SchoolState.PENDING.value
+
+
+def test_onboard_active_school_rejected(
+    client, session, test_user_account, test_user_account_token
+):
+    """Cannot onboard to a school that is already active."""
+    from app.models import School
+    from app.services.experiments import get_experiments
+
+    school = School(
+        name=f"Active School {secrets.token_hex(4)}",
+        country_code="ATA",
+        state=SchoolState.ACTIVE,
+        info={"location": {"state": "Test", "postcode": "1234"}, "experiments": get_experiments({})},
+    )
+    session.add(school)
+    session.commit()
+    session.refresh(school)
+
+    response = client.post(
+        "/v1/onboarding/school",
+        headers={"Authorization": f"Bearer {test_user_account_token}"},
+        json={
+            "school_wriveted_id": str(school.wriveted_identifier),
+            "contact_name": "Test",
+            "contact_email": "test@test.com",
+            "contact_role": "teacher",
+        },
+    )
+    assert response.status_code == 409
+
+
+def test_onboard_missing_school_name_rejected(
+    client, test_user_account, test_user_account_token
+):
+    """Creating a new school requires school_name and country_code."""
+    response = client.post(
+        "/v1/onboarding/school",
+        headers={"Authorization": f"Bearer {test_user_account_token}"},
+        json={
+            "contact_name": "Test",
+            "contact_email": "test@test.com",
+            "contact_role": "teacher",
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_onboard_unauthenticated_rejected(client):
+    """Unauthenticated requests are rejected."""
+    response = client.post(
+        "/v1/onboarding/school",
+        json={
+            "school_name": "Test",
+            "country_code": "ATA",
+            "contact_name": "Test",
+            "contact_email": "test@test.com",
+            "contact_role": "teacher",
+        },
+    )
+    assert response.status_code in (401, 403)
+
+
+def test_onboard_creates_event(
+    client, session, test_user_account, test_user_account_token
+):
+    """Onboarding creates an event visible in the admin UI."""
+    from app.models.event import Event
+
+    school_name = f"Event Test School {secrets.token_hex(4)}"
+    response = client.post(
+        "/v1/onboarding/school",
+        headers={"Authorization": f"Bearer {test_user_account_token}"},
+        json={
+            "school_name": school_name,
+            "country_code": "ATA",
+            "location": {"state": "Test", "postcode": "0000"},
+            "contact_name": "Event Tester",
+            "contact_email": "events@test.com",
+            "contact_role": "principal",
+        },
+    )
+    assert response.status_code == 200
+
+    # Check an event was created
+    events = session.query(Event).filter(
+        Event.title == "School onboarding request"
+    ).all()
+    matching = [e for e in events if school_name in (e.description or "")]
+    assert len(matching) >= 1
+    assert matching[0].info["contact_name"] == "Event Tester"
+
+
+def test_onboard_promotes_user_to_school_admin(
+    client, session, test_user_account, test_user_account_token
+):
+    """The user's account type is promoted from PUBLIC to SCHOOL_ADMIN."""
+    assert test_user_account.type == UserAccountType.PUBLIC
+
+    school_name = f"Promotion Test School {secrets.token_hex(4)}"
+    response = client.post(
+        "/v1/onboarding/school",
+        headers={"Authorization": f"Bearer {test_user_account_token}"},
+        json={
+            "school_name": school_name,
+            "country_code": "ATA",
+            "location": {"state": "Test", "postcode": "0000"},
+            "contact_name": "Promote Test",
+            "contact_email": "promote@test.com",
+            "contact_role": "librarian",
+        },
+    )
+    assert response.status_code == 200
+
+    # Refresh user from DB
+    session.expire_all()
+    from app.models.user import User
+
+    user = session.query(User).get(test_user_account.id)
+    assert user.type == UserAccountType.SCHOOL_ADMIN

--- a/scripts/fixtures/admin-ui-seed.json
+++ b/scripts/fixtures/admin-ui-seed.json
@@ -549,6 +549,7 @@
     {
       "flow_file": "huey-bookbot-flow.json",
       "theme_seed_key": "huey-bookbot-theme"
-    }
+    },
+    {"flow_file": "family-onboarding-flow.json"}
   ]
 }

--- a/scripts/fixtures/family-onboarding-flow.json
+++ b/scripts/fixtures/family-onboarding-flow.json
@@ -1,0 +1,166 @@
+{
+  "seed_key": "family-onboarding",
+  "name": "Family Signup",
+  "description": "Collects parent and child info for family onboarding.",
+  "version": "1.0.0",
+  "entry_node_id": "welcome",
+  "visibility": "wriveted",
+  "flow_data": {
+    "nodes": [
+      {
+        "id": "welcome",
+        "type": "message",
+        "content": {
+          "messages": [
+            {"text": "Welcome to Huey Books! I'm here to help you set up your family account.", "type": "text"},
+            {"type": "image", "content": {"alt": "Huey the Bookbot", "url": "https://storage.googleapis.com/wriveted-huey-media/chat/gifs/Robot(640x640).gif"}},
+            {"text": "I just need a few details about you and your child.", "type": "text"}
+          ]
+        },
+        "position": {"x": 100, "y": 300}
+      },
+      {
+        "id": "ask_parent_name",
+        "type": "question",
+        "content": {
+          "question": {"text": "What's your name?"},
+          "input_type": "text",
+          "variable": "temp.parent_name",
+          "validation": {"required": true, "min_length": 1}
+        },
+        "position": {"x": 300, "y": 300}
+      },
+      {
+        "id": "greet_parent",
+        "type": "message",
+        "content": {
+          "messages": [
+            {"text": "Nice to meet you, {{temp.parent_name}}! Now tell me about your young reader.", "type": "text"}
+          ]
+        },
+        "position": {"x": 500, "y": 300}
+      },
+      {
+        "id": "ask_child_name",
+        "type": "question",
+        "content": {
+          "question": {"text": "What's your child's name?"},
+          "input_type": "text",
+          "variable": "temp.child_name",
+          "validation": {"required": true, "min_length": 1}
+        },
+        "position": {"x": 700, "y": 300}
+      },
+      {
+        "id": "ask_child_age",
+        "type": "question",
+        "content": {
+          "question": {"text": "How old is {{temp.child_name}}?"},
+          "input_type": "choice",
+          "options": [
+            {"label": "5 or under", "value": "5", "age_number": 5},
+            {"label": "6", "value": "6", "age_number": 6},
+            {"label": "7", "value": "7", "age_number": 7},
+            {"label": "8", "value": "8", "age_number": 8},
+            {"label": "9", "value": "9", "age_number": 9},
+            {"label": "10", "value": "10", "age_number": 10},
+            {"label": "11", "value": "11", "age_number": 11},
+            {"label": "12", "value": "12", "age_number": 12},
+            {"label": "13 or over", "value": "13", "age_number": 13}
+          ],
+          "variable": "temp.child_age_selection"
+        },
+        "position": {"x": 900, "y": 300}
+      },
+      {
+        "id": "store_child_age",
+        "type": "action",
+        "content": {
+          "actions": [
+            {"type": "set_variable", "variable": "temp.child_age", "value": "{{temp.child_age_selection.age_number}}"}
+          ]
+        },
+        "position": {"x": 1050, "y": 300}
+      },
+      {
+        "id": "ask_reading_level",
+        "type": "question",
+        "content": {
+          "question": {"text": "What best describes {{temp.child_name}}'s reading?"},
+          "input_type": "choice",
+          "options": [
+            {"label": "Just starting out", "value": "SPOT", "description": "Picture books and simple words"},
+            {"label": "Learning to read", "value": "CAT_HAT", "description": "Short sentences with pictures"},
+            {"label": "Reading independently", "value": "TREEHOUSE", "description": "Short chapters with illustrations"},
+            {"label": "Confident reader", "value": "CHARLIE_CHOCOLATE", "description": "Chapter books"},
+            {"label": "Avid reader", "value": "HARRY_POTTER", "description": "Longer novels"}
+          ],
+          "variable": "temp.reading_level"
+        },
+        "position": {"x": 1200, "y": 300}
+      },
+      {
+        "id": "store_child",
+        "type": "action",
+        "content": {
+          "actions": [
+            {
+              "type": "set_variable",
+              "variable": "temp.children",
+              "value": [{"name": "{{temp.child_name}}", "age": "{{temp.child_age}}", "reading_ability": "{{temp.reading_level.value}}"}]
+            }
+          ]
+        },
+        "position": {"x": 1400, "y": 300}
+      },
+      {
+        "id": "submit_onboarding",
+        "type": "action",
+        "content": {
+          "actions": [
+            {
+              "type": "api_call",
+              "config": {
+                "method": "POST",
+                "endpoint": "/v1/onboarding/family",
+                "body": {
+                  "parent_name": "{{temp.parent_name}}",
+                  "children": "{{temp.children}}"
+                },
+                "response_mapping": {
+                  "children_created": "temp.children_created"
+                },
+                "fallback_response": {
+                  "children_created": 0
+                }
+              }
+            }
+          ]
+        },
+        "position": {"x": 1600, "y": 300}
+      },
+      {
+        "id": "success_msg",
+        "type": "message",
+        "content": {
+          "messages": [
+            {"text": "You're all set, {{temp.parent_name}}! I've created a reader profile for {{temp.child_name}}.", "type": "text"},
+            {"text": "You can now use Huey to find books your child will love. Happy reading!", "type": "text"}
+          ]
+        },
+        "position": {"x": 1800, "y": 300}
+      }
+    ],
+    "connections": [
+      {"source": "welcome", "target": "ask_parent_name", "type": "default"},
+      {"source": "ask_parent_name", "target": "greet_parent", "type": "default"},
+      {"source": "greet_parent", "target": "ask_child_name", "type": "default"},
+      {"source": "ask_child_name", "target": "ask_child_age", "type": "default"},
+      {"source": "ask_child_age", "target": "store_child_age", "type": "default"},
+      {"source": "store_child_age", "target": "ask_reading_level", "type": "default"},
+      {"source": "ask_reading_level", "target": "store_child", "type": "default"},
+      {"source": "store_child", "target": "submit_onboarding", "type": "default"},
+      {"source": "submit_onboarding", "target": "success_msg", "type": "default"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
New `POST /v1/onboarding/school` endpoint for self-service school signup, replacing the Airtable form.

### What it does
1. Accepts authenticated user + school selection/creation data + contact info
2. Creates new school (PENDING state) or selects existing school and sets to PENDING
3. Promotes user from PUBLIC to SCHOOL_ADMIN
4. Binds user as school administrator
5. Stores contact info in school's `info` JSONB under `onboarding` key
6. Creates an event visible in the admin UI for review

### Admin approval flow
- Schools go to PENDING state, visible in admin UI
- Admin reviews and changes state to ACTIVE via existing school edit form
- No auto-approval — all schools require manual review

## Test plan
- [ ] Unit tests pass
- [ ] Integration test: create new school via endpoint
- [ ] Integration test: select existing school via endpoint
- [ ] Verify event appears in admin UI
- [ ] Verify school state is PENDING after onboarding