### PR TITLE
Fix greenlet_spawn in recommendations (intermittent /chat/start 500s)

### DIFF
--- a/app/api/recommendations.py
+++ b/app/api/recommendations.py
@@ -2,7 +2,9 @@ import json
 from typing import Any, Optional, Tuple
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
 from app.api.dependencies.async_db_dep import DBSessionDep
@@ -231,9 +233,18 @@ async def get_recommended_editions_and_labelsets(
 ):
     collection_id = None
     if school_id is not None:
-        school = await school_repository.aget(asession, id=school_id)
+        # Eager-load the collection: school_repository.aget(id) does not, and
+        # accessing the lazy School.collection afterwards raises greenlet_spawn
+        # under the async engine.
+        school = (
+            await asession.execute(
+                select(School)
+                .where(School.id == school_id)
+                .options(selectinload(School.collection))
+            )
+        ).scalar_one_or_none()
         logger.debug("Recommendation request for school", school=school)
-        if school.collection is not None:
+        if school is not None and school.collection is not None:
             collection_id = school.collection.id
         else:
             logger.warning(

--- a/app/services/recommendations.py
+++ b/app/services/recommendations.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import aliased, selectinload
 from structlog import get_logger
 
 from app import crud
@@ -120,8 +120,20 @@ async def get_recommended_labelset_query(
     aliased_edition = aliased(Edition, massive_cte)
     aliased_labelset_end = aliased(LabelSet, massive_cte)
 
-    return select(aliased_work, aliased_edition, aliased_labelset_end).order_by(
-        func.random()
+    # Eager-load the relationships consumed downstream (authors, hues, reading
+    # abilities). They are declared lazy="selectin", but that implicit loader
+    # does not attach to entities aliased against the CTE above, so without
+    # explicit options they lazy-load on attribute access — which happens in
+    # synchronous code (get_authors_string / LabelSetDetail validation) and
+    # raises greenlet_spawn under the async engine.
+    return (
+        select(aliased_work, aliased_edition, aliased_labelset_end)
+        .options(
+            selectinload(aliased_work.authors),
+            selectinload(aliased_labelset_end.hues),
+            selectinload(aliased_labelset_end.reading_abilities),
+        )
+        .order_by(func.random())
     )
 
 


### PR DESCRIPTION
## Root cause
The intermittent `greenlet_spawn has not been called; can't call await_only() here` 500s on `POST /v1/chat/start` trace to the recommendation engine.

`get_recommended_labelset_query` builds a CTE and selects entities **aliased against it** (`aliased_work/edition/labelset`) to shuffle with `ORDER BY random()`. Downstream, `app/api/recommendations.py` reads `work.get_authors_string()` (→ `Work.authors`) and `LabelSetDetail.model_validate(labelset)` (→ `LabelSet.hues`, `LabelSet.reading_abilities`). Those relationships are declared `lazy="selectin"`, but the implicit selectin post-load **does not attach to CTE-aliased entities**, so they fall back to lazy loading on attribute access — which runs in synchronous Python outside the async greenlet → `greenlet_spawn`.

Intermittent because it only fires when (a) the entry flow runs an `api_call` ACTION to `/v1/recommend` during `/chat/start`, and (b) the rows' relationships aren't already in the session identity map. (PR #584 routed the api_call onto the request's async session, exposing this.)

## Fix
- **`app/services/recommendations.py`** — explicit `selectinload()` for `authors`, `hues`, `reading_abilities` on the aliased entities, so they load inside the async context.
- **`app/api/recommendations.py`** — the school-scoped path fetched the school with the non-eager `aget(id)` and then read lazy `school.collection` (same failure class); now fetched with `selectinload(School.collection)`.

## Validation
Lint + compile clean. CI's integration suite exercises `get_recommended_labelset_query` (via the booklist reading-pathway test), so it validates the `selectinload`-on-aliased query still builds and runs.

**Test-coverage note:** there is no integration test for the *API consumption path* (HueyBook construction / `get_authors_string` / `LabelSetDetail` on cold CTE-aliased rows) that actually reproduces this intermittent greenlet error. I didn't add one blind because reproducing it reliably needs a cold async session + seeded editions/labelsets and the Docker test harness to verify — recommend adding that as a follow-up: seed recommendable books, call the recommendation→HueyBook path on a fresh `AsyncSession` (`expunge_all()` first), assert no exception.