### PR TITLE
Greenlet regression tests + drop redundant recommendation selectinload

### DIFF
--- a/app/services/recommendations.py
+++ b/app/services/recommendations.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import aliased, selectinload
+from sqlalchemy.orm import aliased
 from structlog import get_logger
 
 from app import crud
@@ -120,20 +120,8 @@ async def get_recommended_labelset_query(
     aliased_edition = aliased(Edition, massive_cte)
     aliased_labelset_end = aliased(LabelSet, massive_cte)
 
-    # Eager-load the relationships consumed downstream (authors, hues, reading
-    # abilities). They are declared lazy="selectin", but that implicit loader
-    # does not attach to entities aliased against the CTE above, so without
-    # explicit options they lazy-load on attribute access — which happens in
-    # synchronous code (get_authors_string / LabelSetDetail validation) and
-    # raises greenlet_spawn under the async engine.
-    return (
-        select(aliased_work, aliased_edition, aliased_labelset_end)
-        .options(
-            selectinload(aliased_work.authors),
-            selectinload(aliased_labelset_end.hues),
-            selectinload(aliased_labelset_end.reading_abilities),
-        )
-        .order_by(func.random())
+    return select(aliased_work, aliased_edition, aliased_labelset_end).order_by(
+        func.random()
     )
 
 

--- a/app/tests/integration/test_recommendation_greenlet.py
+++ b/app/tests/integration/test_recommendation_greenlet.py
@@ -1,0 +1,85 @@
+"""Regression tests for the greenlet_spawn failures in the recommendation engine.
+
+Background: the recommendation path intermittently 500'd /chat/start with
+"greenlet_spawn has not been called; can't call await_only() here" — sync DB I/O
+triggered under the async engine by a lazily-loaded relationship.
+
+The operative culprit is the school-scoped path: ``School.collection`` is
+``lazy="select"`` (true lazy), so reading it on a cold async session emits a
+synchronous query and raises greenlet_spawn. The fix eager-loads it with
+``selectinload(School.collection)``.
+
+(``Work.authors`` / ``LabelSet.hues`` / ``LabelSet.reading_abilities`` are
+``lazy="selectin"`` and load eagerly during execute, so the
+``test_recommendation_rows_...`` case below is a smoke test of that consumption
+path rather than a regression guard.)
+
+These run against a *cold* async session — data is seeded/committed via the sync
+session and read via a separate async session, so nothing is cached in the async
+session's identity map (matching production, where the request session has not
+already loaded these objects).
+"""
+
+import pytest
+
+from app.api.recommendations import get_recommended_editions_and_labelsets
+from app.models.labelset import RecommendStatus
+from app.models.labelset_hue_association import LabelSetHue, Ordinal
+from app.models.labelset_reading_ability_association import LabelSetReadingAbility
+from app.repositories.labelset_repository import labelset_repository
+from app.schemas.labelset import LabelSetDetail
+from app.services.recommendations import get_recommended_labelset_query
+
+
+@pytest.mark.asyncio
+async def test_school_scoped_recommendation_does_not_greenlet(
+    async_session, test_school_with_collection
+):
+    """Regression for the operative greenlet_spawn: resolving the school's
+    (lazy) collection on a cold async session must not raise."""
+    # Pre-fix this raised greenlet_spawn while reading school.collection.
+    rows = await get_recommended_editions_and_labelsets(
+        async_session,
+        school_id=test_school_with_collection.id,
+        hues=None,
+        reading_abilities=None,
+        age=None,
+        recommendable_only=True,
+        exclude_isbns=None,
+    )
+    assert rows is not None
+
+
+@pytest.mark.asyncio
+async def test_recommendation_rows_consumed_on_cold_session(
+    session, async_session, works_list
+):
+    """Smoke test: building HueyBook-style data (authors, hues, reading
+    abilities) from recommendation rows on a cold async session works."""
+    for work in works_list[:5]:
+        labelset = labelset_repository.create(
+            session,
+            obj_in={
+                "min_age": 5,
+                "max_age": 10,
+                "huey_summary": "A good book",
+                "recommend_status": RecommendStatus.GOOD,
+            },
+        )
+        session.flush()
+        work.labelset = labelset
+        session.add(
+            LabelSetHue(labelset_id=labelset.id, hue_id=1, ordinal=Ordinal.PRIMARY)
+        )
+        session.add(
+            LabelSetReadingAbility(labelset_id=labelset.id, reading_ability_id=2)
+        )
+    session.commit()
+
+    query = await get_recommended_labelset_query(async_session, recommendable_only=True)
+    rows = (await async_session.execute(query.limit(5))).all()
+    assert rows, "expected at least one recommendable book to be returned"
+
+    for work, edition, labelset in rows:
+        assert work.get_authors_string() is not None
+        assert LabelSetDetail.model_validate(labelset) is not None


### PR DESCRIPTION
Follow-up to #649. I reproduced the recommendation `greenlet_spawn` locally (Docker integration harness) and confirmed the real cause.

## What the local repro showed
- **Operative cause:** `School.collection` is `lazy="select"`, so the school-scoped recommendation path raised `sqlalchemy.exc.MissingGreenlet` when reading it on a cold async session. #649's `selectinload(School.collection)` fix resolves it. **Verified:** the new regression test fails with `MissingGreenlet` when that fix is reverted, passes with it.
- **Redundant:** the other half of #649 (explicit `selectinload` on the CTE-aliased Work/LabelSet entities) was unnecessary — `Work.authors`, `LabelSet.hues`, `LabelSet.reading_abilities` are already `lazy="selectin"` and load eagerly during `execute` (the consumption smoke test passes without it). Reverted to keep the query accurate.

## Changes
- **`app/tests/integration/test_recommendation_greenlet.py`** (new):
  - `test_school_scoped_recommendation_does_not_greenlet` — regression guard; reproduces the bug on a cold async session via `test_school_with_collection`.
  - `test_recommendation_rows_consumed_on_cold_session` — smoke test of the authors/hues/reading-abilities consumption path.
- **`app/services/recommendations.py`** — drop the redundant explicit `selectinload`.

## Validation (local Docker harness)
- With fix: both tests pass.
- Revert `selectinload(School.collection)`: `test_school_scoped...` fails with `greenlet_spawn has not been called` (the prod error) — proving the test guards the operative fix.