### PR TITLE
Speed up GET /work/{id} for works with many editions

### DIFF
--- a/app/api/works.py
+++ b/app/api/works.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Path, Security
 from fastapi.params import Query
 from fastapi_permissions import All, Allow, Authenticated
 from sqlalchemy import and_, func, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 from structlog import get_logger
 
 from app import crud
@@ -134,6 +134,20 @@ def get_work_by_id(
             work.info["other"] = {}
             session.add(work)
             session.commit()
+
+        # WorkDetail serialises every edition as an EditionBrief (columns only),
+        # but the Edition model eagerly loads illustrators (subquery), the parent
+        # work (joined), collections (selectin) and a per-row collection_count
+        # subquery. For works with many editions (e.g. 241) that is pathological
+        # — tens of seconds, timing out the request. Load the editions as plain
+        # columns since EditionBrief needs none of those relationships.
+        work = session.scalar(
+            select(Work)
+            .where(Work.id == work.id)
+            .options(
+                selectinload(Work.editions).noload("*").defer(Edition.collection_count)
+            )
+        )
         return WorkDetail.model_validate(work)
 
     else:

--- a/app/api/works.py
+++ b/app/api/works.py
@@ -145,7 +145,8 @@ def get_work_by_id(
             select(Work)
             .where(Work.id == work.id)
             .options(
-                selectinload(Work.editions).noload("*").defer(Edition.collection_count)
+                selectinload(Work.editions).noload("*"),
+                selectinload(Work.editions).defer(Edition.collection_count),
             )
         )
         return WorkDetail.model_validate(work)


### PR DESCRIPTION
`GET /v1/work/{id}?full_detail=true` (the admin Work page — source of the 504 on `/work/3881/`) serialises every edition as `EditionBrief` (columns only), but the `Edition` model eagerly loads `illustrators` (`lazy=subquery`), parent `work` (`lazy=joined`), `collections` (`lazy=selectin`), plus a non-deferred `collection_count` correlated-subquery column_property. For a work with 241 editions that's pathological — ~5s measured, 27s / 120s-timeout (504) under load.

Fix: load editions as plain columns for this response — `selectinload(Work.editions).noload("*").defer(Edition.collection_count)`. `EditionBrief` needs none of those relationships. CI `test_work_api.py` exercises this endpoint; prod latency drop will be verified after deploy.