### PR TITLE
Ranked, typo-tolerant school search (pg_trgm)

### DIFF
--- a/alembic/versions/b7e3f1a9c2d5_add_schools_name_trgm_index.py
+++ b/alembic/versions/b7e3f1a9c2d5_add_schools_name_trgm_index.py
@@ -1,0 +1,34 @@
+"""Add pg_trgm GIN index on schools.name for ranked, typo-tolerant search
+
+Enables similarity()/word_similarity() ranking of school-name search so that
+queries like "Somer" rank Somerfield highly and minor typos still match,
+instead of the previous unranked substring (ILIKE '%q%') filter.
+
+Revision ID: b7e3f1a9c2d5
+Revises: d2a7c9b3e1f4
+Create Date: 2026-06-19 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b7e3f1a9c2d5"
+down_revision = "d2a7c9b3e1f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    # GIN trigram index over lower(name) so that both substring (LIKE) recall
+    # and word_similarity()/similarity() fuzzy ranking can use the index.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_schools_name_trgm "
+        "ON schools USING gin (lower(name) gin_trgm_ops)"
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS idx_schools_name_trgm")

--- a/app/repositories/school_repository.py
+++ b/app/repositories/school_repository.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Optional, Sequence
 
 from fastapi import HTTPException
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, select, text, update
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session, selectinload
@@ -22,6 +22,12 @@ from app.models.user import User, UserAccountType
 from app.schemas.school import SchoolCreateIn, SchoolPatchOptions
 
 logger = get_logger()
+
+# word_similarity threshold for the `%>` operator used in fuzzy school-name
+# search. Lower than the pg_trgm default (0.6) so common typos and
+# transpositions (e.g. "somerfeild" -> "Somerfield") are still recalled, while
+# still letting the GIN trigram index serve the query.
+SCHOOL_SEARCH_WORD_SIMILARITY_THRESHOLD = 0.4
 
 
 class SchoolRepository(ABC):
@@ -231,7 +237,7 @@ class SchoolRepositoryImpl(SchoolRepository):
         official_identifier: Optional[str] = None,
     ):
         """Build a query with optional filters for schools."""
-        from sqlalchemy import func
+        from sqlalchemy import case, func, or_
 
         school_query = select(School).options(
             selectinload(School.subscription).selectinload(Subscription.product),
@@ -247,9 +253,45 @@ class SchoolRepositoryImpl(SchoolRepository):
             school_query = school_query.where(
                 School.info["location", "postcode"].as_string() == postcode
             )
-        if query_string is not None:
+
+        relevance_ordering = None
+        if query_string is not None and query_string.strip():
+            q = query_string.strip().lower()
+            name_lower = func.lower(School.name)
+
+            # word_similarity finds the query as a fuzzy substring within the
+            # (often long) school name; similarity scores the whole string.
+            # GREATEST keeps the stronger of the two signals.
+            word_sim = func.word_similarity(q, name_lower)
+            full_sim = func.similarity(name_lower, q)
+            fuzzy_score = func.greatest(word_sim, full_sim)
+
+            # Boost exact prefix/substring hits above purely fuzzy matches so a
+            # clean partial like "Somer" always outranks a typo-distance match.
+            relevance = fuzzy_score + case(
+                (name_lower.like(q + "%"), 1.0),
+                (name_lower.like("%" + q + "%"), 0.5),
+                else_=0.0,
+            )
+
+            # On a tie (common when two names share the matched word), prefer the
+            # name whose whole string is closest to the query, which favours the
+            # shorter, more specific school over a longer name that merely
+            # contains the same word.
+            relevance_ordering = [relevance.desc(), full_sim.desc()]
+
+            # Recall: keep any substring hit, plus fuzzy hits via the word
+            # similarity operator (catches typos like "Sommerfield" /
+            # "Somerfeild"). Both the LIKE and the `%>` operator are served by
+            # the GIN trigram index (idx_schools_name_trgm) as a BitmapOr, and
+            # `%>` honours pg_trgm.word_similarity_threshold, which the async
+            # caller lowers to SCHOOL_SEARCH_WORD_SIMILARITY_THRESHOLD per
+            # transaction.
             school_query = school_query.where(
-                func.lower(School.name).contains(query_string.lower())
+                or_(
+                    name_lower.like("%" + q + "%"),
+                    name_lower.op("%>")(q),
+                )
             )
         if is_active is not None:
             school_query = school_query.where(
@@ -272,8 +314,15 @@ class SchoolRepositoryImpl(SchoolRepository):
             school_query.options(selectinload(School.country))
             .options(selectinload(School.admins))
             .options(selectinload(School.collection))
-            .order_by(School.created_at.desc())
         )
+
+        if relevance_ordering is not None:
+            school_query = school_query.order_by(
+                *relevance_ordering, School.created_at.desc()
+            )
+        else:
+            school_query = school_query.order_by(School.created_at.desc())
+
         return school_query
 
     async def get_all_with_optional_filters(
@@ -306,6 +355,16 @@ class SchoolRepositoryImpl(SchoolRepository):
             skip=skip,
             limit=limit,
         )
+        if query_string is not None and query_string.strip():
+            # Scope the lowered word_similarity threshold to this transaction so
+            # the fuzzy `%>` recall in the search query stays index-served
+            # without leaking the setting onto pooled connections.
+            await db.execute(
+                text(
+                    "SET LOCAL pg_trgm.word_similarity_threshold = "
+                    f"{SCHOOL_SEARCH_WORD_SIMILARITY_THRESHOLD}"
+                )
+            )
         return (await db.execute(query)).scalars().all()
 
     def create(

--- a/app/tests/integration/test_school_search_ranking.py
+++ b/app/tests/integration/test_school_search_ranking.py
@@ -1,0 +1,106 @@
+"""Ranked, typo-tolerant school-name search.
+
+Exercises the pg_trgm-backed search added to the /v1/schools endpoint: a clean
+partial should surface the school, a minor typo should still recall it, and the
+closest match should rank first.
+"""
+
+import secrets
+
+import pytest
+
+from app.repositories.school_repository import school_repository
+
+# A rare, made-up stem so the assertions are not polluted by real/seeded
+# schools that happen to share common words.
+STEM = "qwzzlebrook"
+
+
+def _create_school(client, headers, name: str) -> str:
+    official_id = secrets.token_hex(8)
+    response = client.post(
+        "/v1/school",
+        headers=headers,
+        json={
+            "name": name,
+            "country_code": "ATA",
+            "official_identifier": official_id,
+            "info": {
+                "msg": "Created for search-ranking test",
+                "location": {"state": "Required", "postcode": "Required"},
+            },
+        },
+        timeout=120,
+    )
+    response.raise_for_status()
+    return response.json()["wriveted_identifier"]
+
+
+@pytest.fixture()
+def search_schools(client, session, backend_service_account_headers):
+    """Create a target school plus a longer one sharing the rare stem."""
+    target_id = _create_school(
+        client, backend_service_account_headers, f"{STEM} School"
+    )
+    longer_id = _create_school(
+        client,
+        backend_service_account_headers,
+        f"North {STEM} Catholic College Senior Campus",
+    )
+    created = {"target": target_id, "longer": longer_id}
+    yield created
+
+    session.rollback()
+    for wriveted_id in created.values():
+        school = school_repository.get_by_wriveted_id(
+            db=session, wriveted_id=wriveted_id
+        )
+        if school is not None:
+            school_repository.remove(db=session, obj_in=school)
+
+
+def _names(response) -> list[str]:
+    response.raise_for_status()
+    return [s["name"] for s in response.json()]
+
+
+def test_exact_partial_ranks_closest_match_first(
+    client, backend_service_account_headers, search_schools
+):
+    """An exact stem ranks the short "<stem> School" above the longer name."""
+    names = _names(
+        client.get(
+            f"/v1/schools?q={STEM}&limit=20", headers=backend_service_account_headers
+        )
+    )
+    assert f"{STEM} School" in names
+    assert f"North {STEM} Catholic College Senior Campus" in names
+    # Prefix match outranks a mid-string match.
+    assert names.index(f"{STEM} School") < names.index(
+        f"North {STEM} Catholic College Senior Campus"
+    )
+
+
+def test_prefix_fragment_recalls_school(
+    client, backend_service_account_headers, search_schools
+):
+    """A short prefix fragment (the original "Somer" failure) still matches."""
+    names = _names(
+        client.get(
+            f"/v1/schools?q={STEM[:5]}&limit=20",
+            headers=backend_service_account_headers,
+        )
+    )
+    assert f"{STEM} School" in names
+
+
+def test_typo_is_tolerated(client, backend_service_account_headers, search_schools):
+    """A single-character deletion still recalls the school and ranks it first."""
+    typo = STEM.replace("zz", "z")  # qwzzlebrook -> qwzlebrook
+    names = _names(
+        client.get(
+            f"/v1/schools?q={typo}&limit=20", headers=backend_service_account_headers
+        )
+    )
+    assert f"{STEM} School" in names
+    assert names[0] == f"{STEM} School"


### PR DESCRIPTION
## What

Replaces the unranked `ILIKE '%q%'` school-name filter on `/v1/schools` with **pg_trgm** trigram search: relevance-ranked and typo-tolerant.

The reported symptom was that searching **"Somer"** (and minor typos) didn't surface **Somerfield** on the review page's school selector. The immediate cause there was a UI shape bug (fixed in admin-UI #57), but the underlying search was also unranked substring matching — this makes it proper search.

## How

- **Migration `b7e3f1a9c2d5`**: `CREATE EXTENSION pg_trgm` + `idx_schools_name_trgm` (`gin (lower(name) gin_trgm_ops)`).
- **Recall**: keep substring (`LIKE`) hits *and* fuzzy hits via the indexable `%>` operator. Both paths are served by the GIN index as a BitmapOr (~0.3ms vs ~43ms seq scan).
- **Ranking**: prefix > substring > fuzzy, with whole-string `similarity()` as a tiebreak so the closest/shortest name wins (e.g. "Qwzzlebrook School" over "North Qwzzlebrook Catholic College Senior Campus").
- **Typos**: the async caller lowers `pg_trgm.word_similarity_threshold` to 0.4 via `SET LOCAL` (transaction-scoped, no pool leak) so single-edit/transposition typos still match.

## Testing

- Validated the exact ranking SQL against **all 13,844 real production school names** (read-only): "Somer" now ranks Somerfield #1; typos "sommerfield" and "somerfeild" both recall Somerfield #1.
- New integration test `test_school_search_ranking.py` (3 cases: exact-partial ranking, prefix fragment recall, typo tolerance) — **passes** via the docker harness with the migration applied.
- `EXPLAIN ANALYZE` confirms BitmapOr index usage.