### PR TITLE
Review queue: cover thumbnails + prioritise books needing attention

### DIFF
--- a/app/repositories/review_repository.py
+++ b/app/repositories/review_repository.py
@@ -265,8 +265,23 @@ class ReviewRepositoryImpl:
         count_stmt = select(func.count()).select_from(stmt.subquery())
         total = db.execute(count_stmt).scalar_one()
 
-        # Order and paginate
+        # Order so reviewing effort lands where it matters most: books that
+        # still need a human look (unchecked or AI-labelled) come first, then by
+        # reach (how many schools stock them), so a reviewer working top-down
+        # confirms the highest-impact unreviewed books before already-reviewed
+        # ones. Human-reviewed books sink to the bottom of the "all" view.
+        needs_attention = case(
+            (
+                (LabelSet.checked.is_(None))
+                | (LabelSet.checked == False)  # noqa: E712
+                | (LabelSet.hue_origin.in_(AI_ORIGINS))
+                | (LabelSet.hue_origin.is_(None)),
+                1,
+            ),
+            else_=0,
+        )
         stmt = stmt.order_by(
+            needs_attention.desc(),
             func.coalesce(cf.c.school_count, 0).desc(),
             Work.id,
         )
@@ -289,6 +304,24 @@ class ReviewRepositoryImpl:
             for hue_row in db.execute(hue_stmt).all():
                 hue_map[hue_row.labelset_id] = hue_row.key
 
+        # One cover per work for the page's rows (bounded to ~limit works).
+        work_ids = [r.work_id for r in rows]
+        cover_map: dict[int, str] = {}
+        if work_ids:
+            cover_stmt = (
+                select(
+                    Edition.work_id,
+                    func.min(Edition.cover_url).label("cover_url"),
+                )
+                .where(
+                    Edition.work_id.in_(work_ids),
+                    Edition.cover_url.isnot(None),
+                )
+                .group_by(Edition.work_id)
+            )
+            for cover_row in db.execute(cover_stmt).all():
+                cover_map[cover_row.work_id] = cover_row.cover_url
+
         items = []
         for row in rows:
             items.append(
@@ -297,6 +330,7 @@ class ReviewRepositoryImpl:
                     "title": row.title,
                     "subtitle": row.subtitle,
                     "leading_article": row.leading_article,
+                    "cover_url": cover_map.get(row.work_id),
                     "authors": [name.strip() for name in (row.author_names or [])],
                     "labelset_id": row.labelset_id,
                     "hue_primary_key": hue_map.get(row.labelset_id),

--- a/app/schemas/review.py
+++ b/app/schemas/review.py
@@ -52,6 +52,7 @@ class ReviewQueueItem(BaseModel):
     title: str
     subtitle: str | None = None
     leading_article: str | None = None
+    cover_url: str | None = None
     authors: list[str]
     labelset_id: int | None = None
     hue_primary_key: str | None = None

--- a/app/tests/integration/test_review_queue.py
+++ b/app/tests/integration/test_review_queue.py
@@ -1,0 +1,104 @@
+"""Review queue ordering and cover thumbnails.
+
+Covers two behaviours of ``review_repository.get_review_queue``:
+- it returns a cover image URL for each work (for the queue/modal thumbnails);
+- it surfaces books that still need a human look (unchecked / AI-labelled)
+  ahead of already human-reviewed books, so reviewing effort lands first on
+  the books that need it.
+"""
+
+import uuid
+
+from app.models.edition import Edition
+from app.models.labelset import LabelOrigin, LabelSet
+from app.models.work import Work, WorkType
+from app.repositories.review_repository import review_repository
+
+
+def _unique_isbn() -> str:
+    # Unique within the shared test DB; format is unimportant for these tests.
+    return f"978{uuid.uuid4().int % 10_000_000_000:010d}"
+
+
+def _make_work(
+    session,
+    *,
+    title: str,
+    cover_url: str | None,
+    hue_origin: LabelOrigin | None,
+    checked: bool | None,
+) -> Work:
+    work = Work(type=WorkType.BOOK, title=title)
+    session.add(work)
+    session.flush()
+
+    session.add(
+        Edition(isbn=_unique_isbn(), work_id=work.id, cover_url=cover_url, info={})
+    )
+    session.add(LabelSet(work_id=work.id, hue_origin=hue_origin, checked=checked))
+    session.commit()
+    return work
+
+
+def test_review_queue_includes_cover_url(session):
+    cover = "https://covers.test/peach.jpg"
+    work = _make_work(
+        session,
+        title=f"Cover Test {uuid.uuid4().hex[:8]}",
+        cover_url=cover,
+        hue_origin=LabelOrigin.CLUSTER_RELEVANCE,
+        checked=False,
+    )
+
+    items, _ = review_repository.get_review_queue(
+        db=session, status="all", limit=100_000
+    )
+
+    item = next((i for i in items if i["work_id"] == work.id), None)
+    assert item is not None, "newly created work should appear in the queue"
+    assert item["cover_url"] == cover
+
+
+def test_review_queue_prioritises_books_needing_attention(session):
+    """An AI-labelled, unchecked book should rank above a human-reviewed,
+    checked one regardless of insertion order."""
+    # Insert the already-done book first so insertion order can't explain a pass.
+    done = _make_work(
+        session,
+        title=f"Done {uuid.uuid4().hex[:8]}",
+        cover_url=None,
+        hue_origin=LabelOrigin.HUMAN,
+        checked=True,
+    )
+    needs = _make_work(
+        session,
+        title=f"Needs {uuid.uuid4().hex[:8]}",
+        cover_url=None,
+        hue_origin=LabelOrigin.CLUSTER_RELEVANCE,
+        checked=False,
+    )
+
+    items, _ = review_repository.get_review_queue(
+        db=session, status="all", limit=100_000
+    )
+    ids = [i["work_id"] for i in items]
+
+    assert needs.id in ids and done.id in ids
+    assert ids.index(needs.id) < ids.index(done.id)
+
+
+def test_review_queue_human_reviewed_filter_excludes_unchecked(session):
+    """Sanity check that the status filter still works after the ordering
+    change: a freshly AI-labelled book is not in the human-reviewed view."""
+    work = _make_work(
+        session,
+        title=f"Filter {uuid.uuid4().hex[:8]}",
+        cover_url=None,
+        hue_origin=LabelOrigin.CLUSTER_RELEVANCE,
+        checked=False,
+    )
+
+    items, _ = review_repository.get_review_queue(
+        db=session, status="human_reviewed", limit=100_000
+    )
+    assert work.id not in [i["work_id"] for i in items]


### PR DESCRIPTION
## What

Two backend improvements to the review queue (pairs with admin-UI #58):

1. **Cover thumbnails** — `/review-queue` items now include `cover_url` (one cover per work, fetched in a single bounded query per page), so the queue table and review modal can show book covers.
2. **Smarter ordering** — the queue now surfaces books that still need a human look (unchecked or AI-labelled) **before** already human-reviewed ones, then by reach (`school_count`). A reviewer working top-down hits the highest-impact unreviewed books first instead of re-encountering already-confirmed ones.

## Testing

New `app/tests/integration/test_review_queue.py` (3 cases, all passing via the docker harness):
- `cover_url` is returned for a work with a cover.
- an AI-labelled, unchecked book ranks above a human-reviewed, checked one (regardless of insertion order).
- the `human_reviewed` status filter still excludes a freshly AI-labelled book.

`ruff check` clean.