### PR TITLE
Enable Cloud Run startup CPU boost on prod API (cut cold starts)

### DIFF
--- a/.cloudbuild/cloudbuild-main-branch.yaml
+++ b/.cloudbuild/cloudbuild-main-branch.yaml
@@ -116,6 +116,9 @@ steps:
       - "--region=$_DEPLOY_REGION"
       - "--concurrency=20"
       - "--max-instances=6"
+      # Full CPU during startup so the ~10s app import + image decompress aren't
+      # CPU-throttled — meaningfully cuts cold-start latency at no idle cost.
+      - "--cpu-boost"
       - "--quiet"
       - >-
         --set-env-vars=


### PR DESCRIPTION
## Problem
Cold starts on `wriveted-api` were measured at **up to ~170s** (warm requests: **0.5s**). After idle/deploy, the first request boots a fresh instance.

## Investigation (measured)
| Component | Cost |
|---|---|
| Image pull (718 MB, fresh node — worst right after deploy) | tens of seconds |
| `import app.main` | **10.5s** (router/model graph **8.0s**, OTel/logging 1.4s, openai 1.1s) |
| Lifespan (Postgres LISTEN connect + webhook init) | a few seconds |
| …all on **throttled** startup CPU | ✕ multiplier |
| Warm request | 0.5s |

The endpoint/query is innocent — it's startup cost, and it's **CPU-bound**, so it's worse under Cloud Run's throttled startup CPU.

## Fix
Add **`--cpu-boost`** to the prod `wriveted-api` deploy step. It grants full CPU during container startup, speeding both the 10.5s import and image decompress. **No idle/recurring cost** — boost only applies during startup.

The 8s router import is inherent to the app's size (lazy-router refactor = high effort, low certainty); the image is already slim-based + multi-stage. `--cpu-boost` is the high-leverage, zero-cost lever.

Validated: YAML parses; flag is valid for `gcloud run services update`.