### PR TITLE
Fix self-amplifying flow-event dispatch (chat interact latency)

### DIFF
--- a/app/services/event_listener.py
+++ b/app/services/event_listener.py
@@ -148,9 +148,15 @@ class FlowEventListener:
                 f"Received flow event: {flow_event.event_type} for session {flow_event.session_id}"
             )
 
-            # Dispatch to registered handlers
-            handlers = self.handlers.get(flow_event.event_type, [])
-            handlers.extend(self.handlers.get("*", []))  # Wildcard handlers
+            # Dispatch to registered handlers. Build a NEW list — never mutate
+            # the stored handler list. `dict.get` returns the live list, so an
+            # in-place extend would append the wildcard handlers to
+            # self.handlers[event_type] on every notification, growing the list
+            # unboundedly and fanning each event out to ever-more handlers.
+            handlers = [
+                *self.handlers.get(flow_event.event_type, []),
+                *self.handlers.get("*", []),
+            ]
 
             for handler in handlers:
                 try:

--- a/app/tests/unit/test_event_listener_amplification.py
+++ b/app/tests/unit/test_event_listener_amplification.py
@@ -1,0 +1,46 @@
+"""Regression test: flow-event dispatch must not amplify over time.
+
+`_handle_notification` previously did `handlers = self.handlers.get(type, [])`
+(the *live* list) then `handlers.extend(self.handlers.get("*"))`, mutating the
+stored list. Each notification re-appended the wildcard handlers, so the
+handler list grew unboundedly and every event fanned out to ever-more handlers
+— a self-amplifying dispatch storm that degraded long-lived instances.
+"""
+
+import json
+import uuid
+
+from app.services.event_listener import FlowEventListener
+
+
+def _payload(event_type: str = "node_changed") -> str:
+    return json.dumps(
+        {
+            "event_type": event_type,
+            "session_id": str(uuid.uuid4()),
+            "flow_id": str(uuid.uuid4()),
+            "timestamp": 0.0,
+            "current_node": "show_books",
+        }
+    )
+
+
+async def test_repeated_notifications_do_not_grow_handler_lists():
+    listener = FlowEventListener()
+    calls = {"wildcard": 0, "typed": 0}
+    listener.register_handler("*", lambda e: calls.__setitem__("wildcard", calls["wildcard"] + 1))
+    listener.register_handler(
+        "node_changed", lambda e: calls.__setitem__("typed", calls["typed"] + 1)
+    )
+
+    for _ in range(5):
+        await listener._handle_notification(None, 0, "flow_events", _payload())
+
+    # Stored handler lists must stay at their registered size (regression: the
+    # in-place extend grew node_changed by one wildcard handler per call).
+    assert len(listener.handlers["node_changed"]) == 1
+    assert len(listener.handlers["*"]) == 1
+
+    # Each handler fires exactly once per notification — not 1, 2, 3, ... times.
+    assert calls["typed"] == 5
+    assert calls["wildcard"] == 5


### PR DESCRIPTION
## Problem
Investigating warm `/chat/sessions/{id}/interact` calls taking **20–48s**, the logs showed a *flood* of duplicate `node_changed` dispatches (dozens within one millisecond), accounting for ~15s of a 48s interact — and worsening the longer an instance runs.

## Root cause
`FlowEventListener._handle_notification`:
```python
handlers = self.handlers.get(flow_event.event_type, [])   # the LIVE stored list
handlers.extend(self.handlers.get("*", []))               # mutates it in place
```
`dict.get` returns the actual stored list, so the in-place `extend` appends the wildcard handlers to `self.handlers[event_type]` **on every notification**. The list grows unboundedly and each event fans out to ever-more handlers — a self-amplifying dispatch storm on the event loop. (This is the "are we blocking in async?" symptom: not a sync call, but redundant async dispatch that compounds over the instance lifetime.)

## Fix
Build a new list instead of mutating the stored one. One-liner + a regression test asserting the handler lists stay fixed-size and each handler fires exactly once per notification (the test fails on the old code: `assert 6 == 1` after 5 notifications).

## Scope
This addresses the **~15s event-storm** half of the slow interact. The other half — the **recommendation engine taking ~24s** (progressive fallback queries; the widest reading-ability fallback ~17s) — is a separate, deeper query-perf issue I'll tackle next.