### PR TITLE
Recommendation engine: materialized view + single-pass scored query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,32 @@ See [docs/architecture-service-layer.md](docs/architecture-service-layer.md) for
 ### Performance
 - Bulk operations: use batch create/update for efficiency
 - Full-text search uses PostgreSQL tsvector and GIN indexes
+- Recommendations use the `recommendable_editions` materialized view (see below)
+
+### Recommendation Engine (`recommendable_editions` MV)
+
+The recommendation system is backed by a materialized view pre-computing one row
+per work (latest labelset, best cover edition, hue/reading-ability key arrays).
+
+**Key files**:
+- `app/db/views.py` — `PGMaterializedView` definition
+- `app/db/functions.py` — `refresh_recommendable_editions_function` (non-blocking CONCURRENTLY refresh)
+- `app/services/recommendations.py` — `get_recommended_editions_from_mv` (scored query)
+- `app/api/recommendations.py` — single-pass scored API, replacing the old 4-level fallback
+
+**Scoring** (higher wins): school-collection match (4), reading-ability overlap (2), hue overlap (1).
+Results ordered by score DESC then random() within each tier.
+
+**Refresh**:
+- Weekly via Cloud Scheduler → `POST /maintenance/refresh-recommendations` (internal API)
+- Debounced on label writes (`PATCH /labelsets`, `PATCH /work/{id}` label edits,
+  and promoted reviews) via Cloud Tasks named task `refresh-recommendable-editions`
+  (deduplicates within ~4-hour GCP window; fires ~60 s after the last write)
+
+After adding or modifying labelsets in bulk, force a refresh locally with:
+```sql
+REFRESH MATERIALIZED VIEW CONCURRENTLY recommendable_editions;
+```
 
 ### REST Conventions
 - Verify actual API behavior vs REST conventions for status codes

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -28,6 +28,7 @@ from app.db.functions import (
     cms_content_tsvector_update,
     notify_flow_event_function,
     public_encode_uri_component,
+    refresh_recommendable_editions_function,
     refresh_search_view_v1_function,
     refresh_work_collection_frequency_view_function,
     update_collections_function,
@@ -41,7 +42,11 @@ from app.db.triggers import (
     update_collections_trigger,
     works_update_edition_title_from_work_trigger,
 )
-from app.db.views import collection_frequency_view, search_view_v1
+from app.db.views import (
+    collection_frequency_view,
+    recommendable_editions_view,
+    search_view_v1,
+)
 
 register_entities(
     [
@@ -54,12 +59,14 @@ register_entities(
         update_collections_function,
         refresh_search_view_v1_function,
         refresh_work_collection_frequency_view_function,
+        refresh_recommendable_editions_function,
         public_encode_uri_component,
         cms_content_tsvector_update,
         notify_flow_event_function,
         # Views
         collection_frequency_view,
         search_view_v1,
+        recommendable_editions_view,
         # Triggers
         editions_update_edition_title_trigger,
         works_update_edition_title_from_work_trigger,

--- a/alembic/versions/a1b2c3d4e5f6_add_recommendable_editions_mv.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_recommendable_editions_mv.py
@@ -1,0 +1,84 @@
+"""Add recommendable_editions materialized view and refresh function
+
+Pre-computes one row per recommendable work (latest labelset, cover edition,
+hue/reading-ability key arrays) so the recommendation query can hit a small
+indexed table instead of re-joining the full labelsets/editions/hues graph on
+every request.
+
+Revision ID: a1b2c3d4e5f6
+Revises: c4e8a1f6d2b9
+Create Date: 2026-06-23 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "c4e8a1f6d2b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    from app.db.functions import refresh_recommendable_editions_function
+    from app.db.views import recommendable_editions_view
+
+    # Create the materialized view (WITH DATA so it's immediately queryable)
+    op.create_entity(recommendable_editions_view)
+
+    # Unique index on work_id — required for REFRESH MATERIALIZED VIEW CONCURRENTLY
+    # (and backs the work_id lookups in the scored query).
+    op.create_index(
+        "uix_recommendable_editions_work_id",
+        "recommendable_editions",
+        ["work_id"],
+        unique=True,
+    )
+
+    # GIN indexes for array overlap queries (hue_keys && :hues, reading_ability_keys && :ras)
+    op.create_index(
+        "ix_recommendable_editions_hue_keys",
+        "recommendable_editions",
+        ["hue_keys"],
+        postgresql_using="gin",
+    )
+    op.create_index(
+        "ix_recommendable_editions_reading_ability_keys",
+        "recommendable_editions",
+        ["reading_ability_keys"],
+        postgresql_using="gin",
+    )
+
+    # Btree index covering the hard-filter columns used on every recommendation query
+    op.create_index(
+        "ix_recommendable_editions_status_ages",
+        "recommendable_editions",
+        ["recommend_status", "min_age", "max_age"],
+    )
+
+    # The refresh function (REFRESH MATERIALIZED VIEW CONCURRENTLY)
+    op.create_entity(refresh_recommendable_editions_function)
+
+
+def downgrade() -> None:
+    from app.db.functions import refresh_recommendable_editions_function
+    from app.db.views import recommendable_editions_view
+
+    op.drop_entity(refresh_recommendable_editions_function)
+
+    op.drop_index(
+        "ix_recommendable_editions_status_ages", table_name="recommendable_editions"
+    )
+    op.drop_index(
+        "ix_recommendable_editions_reading_ability_keys",
+        table_name="recommendable_editions",
+    )
+    op.drop_index(
+        "ix_recommendable_editions_hue_keys", table_name="recommendable_editions"
+    )
+    op.drop_index(
+        "uix_recommendable_editions_work_id", table_name="recommendable_editions"
+    )
+
+    op.drop_entity(recommendable_editions_view)

--- a/app/api/internal/__init__.py
+++ b/app/api/internal/__init__.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from pydantic_settings import BaseSettings
 from sendgrid import SendGridAPIClient
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 from structlog import get_logger
 from twilio.rest import Client as TwilioClient
@@ -264,3 +265,23 @@ async def handle_cleanup_abandoned_sessions(
         inactive_hours=inactive_hours,
     )
     return {"msg": "ok", "abandoned": count, "inactive_hours": inactive_hours}
+
+
+@router.post("/maintenance/refresh-recommendations")
+async def handle_refresh_recommendations(session: DBSessionDep):
+    """
+    Refresh the recommendable_editions materialized view.
+
+    Uses REFRESH MATERIALIZED VIEW CONCURRENTLY so reads are not blocked during
+    the refresh.  Intended to be called on a weekly Cloud Scheduler job (OIDC
+    auth via the background-tasks service account) so that newly labelled or
+    updated works become visible to the recommendation engine without a deploy.
+
+    The view can also be refreshed on-demand after bulk labelset/collection
+    mutations via the debounced Cloud Tasks path (see
+    app/services/recommendations.py:enqueue_debounced_mv_refresh).
+    """
+    logger.info("Refreshing recommendable_editions materialized view")
+    await session.execute(text("SELECT refresh_recommendable_editions_function()"))
+    logger.info("Refreshed recommendable_editions materialized view")
+    return {"msg": "ok"}

--- a/app/api/labelset.py
+++ b/app/api/labelset.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends
 from sqlalchemy.orm import Session
 from structlog import get_logger
 
@@ -9,6 +9,7 @@ from app.db.session import get_session
 from app.repositories.labelset_repository import labelset_repository
 from app.repositories.work_repository import work_repository
 from app.schemas.labelset import LabelSetPatch
+from app.services.recommendations import enqueue_debounced_mv_refresh
 
 logger = get_logger()
 
@@ -21,6 +22,7 @@ router = APIRouter(
 @router.patch("/labelsets")
 async def bulk_patch_labelsets(
     patches: list[LabelSetPatch],
+    background_tasks: BackgroundTasks,
     session: Session = Depends(get_session),
 ):
     patched = 0
@@ -39,15 +41,18 @@ async def bulk_patch_labelsets(
                 session, labelset, patch.patch_data, False
             )
 
-            # TODO: add to Huey's Picks booklist
-            # if patch.huey_pick:
-            #     work.booklists.append(crud.booklists.get_by_key("wriveted_hueypicks"))
-
             session.commit()
             patched += 1
         except Exception as ex:
             print(ex)
             errors += 1
             continue
+
+    if patched > 0:
+        # Enqueue a debounced MV refresh after labelset mutations so the
+        # recommendation engine reflects the changes within ~1 minute.
+        # Named Cloud Tasks deduplication ensures many rapid writes collapse
+        # into a single refresh (see enqueue_debounced_mv_refresh docstring).
+        background_tasks.add_task(enqueue_debounced_mv_refresh)
 
     return {"patched": patched, "unknown": unknown, "errors": errors}

--- a/app/api/recommendations.py
+++ b/app/api/recommendations.py
@@ -2,9 +2,7 @@ import json
 from typing import Any, Optional, Tuple
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Query
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
 from app.api.dependencies.async_db_dep import DBSessionDep
@@ -14,13 +12,8 @@ from app.models import EventLevel, School
 from app.repositories.event_repository import event_repository
 from app.repositories.school_repository import school_repository
 from app.schemas.labelset import LabelSetDetail
-from app.schemas.recommendations import (
-    HueyBook,
-    HueyOutput,
-    HueyRecommendationFilter,
-    ReadingAbilityKey,
-)
-from app.services.recommendations import get_recommended_labelset_query
+from app.schemas.recommendations import HueyBook, HueyOutput, HueyRecommendationFilter
+from app.services.recommendations import get_recommended_editions_from_mv
 
 router = APIRouter(
     tags=["Recommendations"],
@@ -41,7 +34,8 @@ async def get_recommendations(
     """
     Fetch labeled works as recommended by Huey.
 
-    Note this endpoint returns recommendations in a random order.
+    Returns recommendations ordered by relevance score (school-collection match,
+    reading-ability match, hue match), then random within each score tier.
     """
     logger.debug("Recommendation endpoint called", parameters=data)
 
@@ -49,7 +43,6 @@ async def get_recommendations(
         school = await school_repository.aget_by_wriveted_id_or_404(
             db=asession, wriveted_id=data.wriveted_identifier
         )
-        # TODO check account is allowed to `read` school
     else:
         school = None
 
@@ -78,9 +71,14 @@ async def get_recommendations_with_fallback(
     remove_duplicate_authors=True,
 ) -> Tuple[list[HueyBook], Any]:
     """
-    Returns a tuple containing:
-    - a list of HueyBook instances,
-    - final set of query parameters used
+    Return (filtered_books, query_parameters) by running a single scored query
+    over the recommendable_editions materialized view.
+
+    The MV query applies hard filters (recommend_status, age, exclude_isbns) and
+    scores candidates by soft criteria (school-collection membership weighted 4,
+    reading-ability overlap weighted 2, hue overlap weighted 1), then orders by
+    score DESC + random() within each tier.  This replaces the previous four
+    sequential fallback passes.
     """
     school_id = school.id if school is not None else None
     query_parameters = {
@@ -93,69 +91,11 @@ async def get_recommendations_with_fallback(
         "limit": limit + 5,
     }
     logger.info("About to make a recommendation", query_parameters=query_parameters)
+
     row_results = await get_recommended_editions_and_labelsets(
         asession, **query_parameters
     )
     logger.debug("Have got recommendation results from database")
-    fallback_level = 0
-    if data.fallback and len(row_results) < 3:
-        fallback_level += 1
-        # proper fallback logic can come later when booklists are implemented
-        query_parameters["school_id"] = None
-        logger.info(
-            f"Desired query returned {len(row_results)} books. Trying fallback method 1 of looking outside school collection",
-            query_parameters=query_parameters,
-        )
-        row_results = await get_recommended_editions_and_labelsets(
-            asession, **query_parameters
-        )
-    if len(row_results) < 3:
-        logger.debug(
-            "Still not enough, alright let's recommend outside the school collection"
-        )
-        fallback_level += 1
-        # Let's just include all the hues and try the query again.
-        query_parameters["hues"] = None
-        logger.info(
-            f"Desired query returned {len(row_results)} books. Trying fallback method 2 of including all hues",
-            query_parameters=query_parameters,
-        )
-        row_results = await get_recommended_editions_and_labelsets(
-            asession, **query_parameters
-        )
-    if len(row_results) < 3:
-        fallback_level += 1
-        logger.debug("Widen the reading ability")
-        if len(query_parameters["reading_abilities"]) == 1:
-            match query_parameters["reading_abilities"][0]:
-                case ReadingAbilityKey.HARRY_POTTER:
-                    query_parameters["reading_abilities"].append(
-                        ReadingAbilityKey.CHARLIE_CHOCOLATE
-                    )
-                case ReadingAbilityKey.SPOT:
-                    query_parameters["reading_abilities"].append(
-                        ReadingAbilityKey.CAT_HAT
-                    )
-                case _:
-                    query_parameters["reading_abilities"].append(
-                        ReadingAbilityKey.TREEHOUSE
-                    )
-            logger.info(
-                f"Desired query returned {len(row_results)} books. Trying fallback method 3 of including widening the reading ability",
-                query_parameters=query_parameters,
-            )
-        elif query_parameters["age"] is not None:
-            logger.warning("Incrementing age")
-            query_parameters["age"] += 2
-            logger.info(
-                f"Desired query returned {len(row_results)} books. Trying fallback method of increasing the age",
-                query_parameters=query_parameters,
-            )
-        else:
-            logger.warning("No recommendations available")
-        row_results = await get_recommended_editions_and_labelsets(
-            asession, **query_parameters
-        )
 
     # Note the row_results are an iterable of (work, edition, labelset) orm instances
     # Now we convert that to a list of HueyBook instances:
@@ -174,7 +114,6 @@ async def get_recommendations_with_fallback(
     filtered_books = []
     if len(recommended_books) > 1:
         if remove_duplicate_authors:
-            # While we have more than the desired number of books, remove any works from the same author
             current_authors = set()
             for book in recommended_books:
                 if book.authors_string not in current_authors:
@@ -188,8 +127,6 @@ async def get_recommendations_with_fallback(
                 if len(filtered_books) >= limit:
                     break
 
-        # Bit annoying to dump and load json here but we want to fully serialize the JSON ready for
-        # inserting into postgreSQL, which BaseModel.dict() doesn't do
         event_recommendation_data = [json.loads(b.json()) for b in filtered_books[:10]]
 
         await event_repository.acreate(
@@ -199,7 +136,6 @@ async def get_recommendations_with_fallback(
             info={
                 "recommended": event_recommendation_data,
                 "query_parameters": query_parameters,
-                "fallback_level": fallback_level,
             },
             school=school,
             account=account,
@@ -210,10 +146,7 @@ async def get_recommendations_with_fallback(
                 asession,
                 title="No books",
                 description="No books met the criteria for recommendation",
-                info={
-                    "query_parameters": query_parameters,
-                    "fallback_level": fallback_level,
-                },
+                info={"query_parameters": query_parameters},
                 school=school,
                 account=account,
                 level=EventLevel.WARNING,
@@ -231,46 +164,20 @@ async def get_recommended_editions_and_labelsets(
     exclude_isbns,
     limit=5,
 ):
-    collection_id = None
-    if school_id is not None:
-        # Eager-load the collection: school_repository.aget(id) does not, and
-        # accessing the lazy School.collection afterwards raises greenlet_spawn
-        # under the async engine.
-        school = (
-            await asession.execute(
-                select(School)
-                .where(School.id == school_id)
-                .options(selectinload(School.collection))
-            )
-        ).scalar_one_or_none()
-        logger.debug("Recommendation request for school", school=school)
-        if school is not None and school.collection is not None:
-            collection_id = school.collection.id
-        else:
-            logger.warning(
-                "School recommendation was requested, but school doesn't have a collection!",
-                school=school,
-            )
+    """
+    Fetch (Work, Edition, LabelSet) tuples from the recommendable_editions MV.
 
-    query = await get_recommended_labelset_query(
+    The MV pre-computes one row per work (latest labelset, one cover edition,
+    aggregated hue/reading-ability keys), so this query avoids the expensive
+    multi-join + DISTINCT ON that caused the original 16-second plans.
+    """
+    return await get_recommended_editions_from_mv(
         asession,
         hues=hues,
-        collection_id=collection_id,
+        school_id=school_id,
         age=age,
         reading_abilities=reading_abilities,
         recommendable_only=recommendable_only,
         exclude_isbns=exclude_isbns,
+        limit=limit,
     )
-
-    logger.debug("Recommendation query prepared")
-
-    # if True:
-    #     explain_results = (
-    #         (await asession.execute(explain(query, analyze=True))).scalars().all()
-    #     )
-    #     logger.info("Query plan")
-    #     for entry in explain_results:
-    #         logger.info(entry)
-
-    row_results = (await asession.execute(query.limit(limit))).all()
-    return row_results

--- a/app/api/reviews.py
+++ b/app/api/reviews.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional, Union
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Path, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, Path, Query
 from fastapi_permissions import All, Allow
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -29,6 +29,7 @@ from app.schemas.review import (
     ReviewQueueItem,
     ReviewStats,
 )
+from app.services.recommendations import enqueue_debounced_mv_refresh
 
 logger = get_logger()
 
@@ -80,6 +81,7 @@ def _review_to_detail(review) -> LabelSetReviewDetail:
 )
 def submit_review(
     review_data: LabelSetReviewIn,
+    background_tasks: BackgroundTasks,
     work: Work = Depends(get_work),
     account: Union[User, ServiceAccount] = Depends(
         get_current_active_user_or_service_account
@@ -114,6 +116,7 @@ def submit_review(
     # labelset as staff-checked; teachers carry EDUCATOR authority (above AI,
     # below staff) and leave the staff-confirmation flag untouched, so their
     # input improves recommendations immediately without bypassing QA.
+    promoted = False
     if account.type == UserAccountType.WRIVETED:
         _promote_review_to_canonical(
             session,
@@ -123,6 +126,7 @@ def submit_review(
             origin=LabelOrigin.HUMAN,
             mark_checked=True,
         )
+        promoted = True
     elif account.type in (UserAccountType.EDUCATOR, UserAccountType.SCHOOL_ADMIN):
         _promote_review_to_canonical(
             session,
@@ -132,6 +136,14 @@ def submit_review(
             origin=LabelOrigin.EDUCATOR,
             mark_checked=False,
         )
+        promoted = True
+
+    if promoted:
+        # A promoted review mutates the canonical labelset, changing
+        # recommendation scoring/eligibility, so debounce a MV refresh
+        # (see enqueue_debounced_mv_refresh). Non-promoting reviews (e.g. from
+        # students) don't touch the labelset, so no refresh is needed.
+        background_tasks.add_task(enqueue_debounced_mv_refresh)
 
     logger.info(
         "Review submitted",

--- a/app/api/works.py
+++ b/app/api/works.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, Path, Security
+from fastapi import APIRouter, BackgroundTasks, Depends, Path, Security
 from fastapi.params import Query
 from fastapi_permissions import All, Allow, Authenticated
 from sqlalchemy import and_, func, select
@@ -32,6 +32,7 @@ from app.schemas.work import (
 )
 from app.services.background_tasks import queue_background_task
 from app.services.editions import get_definitive_isbn
+from app.services.recommendations import enqueue_debounced_mv_refresh
 
 """
 Access control rules applying to all Works endpoints.
@@ -273,6 +274,7 @@ def create_work_with_editions(
 )
 def update_work(
     changes: WorkUpdateIn,
+    background_tasks: BackgroundTasks,
     work_orm: Work = Depends(get_work),
     account=Depends(get_current_active_user_or_service_account),
     session: Session = Depends(get_session),
@@ -315,6 +317,11 @@ def update_work(
         },
         account=account,
     )
+
+    if labelset_changes:
+        # Label edits change recommendation eligibility/scoring, so debounce a
+        # refresh of the recommendable_editions MV (see enqueue_debounced_mv_refresh).
+        background_tasks.add_task(enqueue_debounced_mv_refresh)
 
     return updated
 

--- a/app/db/functions.py
+++ b/app/db/functions.py
@@ -63,6 +63,20 @@ refresh_search_view_v1_function = PGFunction(
     """,
 )
 
+refresh_recommendable_editions_function = PGFunction(
+    schema="public",
+    signature="refresh_recommendable_editions_function()",
+    definition="""returns void LANGUAGE plpgsql
+      AS $function$
+        BEGIN
+        -- CONCURRENTLY avoids an ACCESS EXCLUSIVE lock so recommendation reads are
+        -- not blocked during the refresh; it requires the unique index on work_id.
+        REFRESH MATERIALIZED VIEW CONCURRENTLY public.recommendable_editions;
+        END;
+      $function$
+    """,
+)
+
 refresh_work_collection_frequency_view_function = PGFunction(
     schema="public",
     signature="refresh_work_collection_frequency_view_function()",

--- a/app/db/views.py
+++ b/app/db/views.py
@@ -1,5 +1,51 @@
 from alembic_utils.pg_materialized_view import PGMaterializedView
 
+recommendable_editions_view = PGMaterializedView(
+    schema="public",
+    signature="recommendable_editions",
+    definition="""
+SELECT
+    ls.work_id,
+    ls.id                         AS labelset_id,
+    ls.min_age,
+    ls.max_age,
+    ls.recommend_status,
+    cover_ed.isbn                 AS cover_edition_isbn,
+    cover_ed.cover_url,
+    COALESCE(
+        array_agg(DISTINCT h.key) FILTER (WHERE h.key IS NOT NULL),
+        '{}'
+    )                             AS hue_keys,
+    COALESCE(
+        array_agg(DISTINCT ra.key) FILTER (WHERE ra.key IS NOT NULL),
+        '{}'
+    )                             AS reading_ability_keys
+FROM (
+    SELECT DISTINCT ON (work_id) *
+    FROM   public.labelsets
+    ORDER  BY work_id, id DESC
+) ls
+-- One cover edition per work, chosen deterministically (lowest isbn with a non-null cover_url)
+JOIN LATERAL (
+    SELECT e.isbn, e.cover_url
+    FROM   public.editions e
+    WHERE  e.work_id = ls.work_id
+      AND  e.cover_url IS NOT NULL
+    ORDER  BY e.isbn
+    LIMIT  1
+) cover_ed ON TRUE
+-- Hue keys for this labelset
+LEFT JOIN public.labelset_hue_association lha ON lha.labelset_id = ls.id
+LEFT JOIN public.hues                     h   ON h.id = lha.hue_id
+-- Reading ability keys for this labelset
+LEFT JOIN public.labelset_reading_ability_association lra ON lra.labelset_id = ls.id
+LEFT JOIN public.reading_abilities                    ra  ON ra.id = lra.reading_ability_id
+GROUP BY ls.work_id, ls.id, ls.min_age, ls.max_age, ls.recommend_status,
+         cover_ed.isbn, cover_ed.cover_url
+    """,
+    with_data=True,
+)
+
 collection_frequency_view = PGMaterializedView(
     schema="public",
     signature="work_collection_frequency",

--- a/app/services/recommendations.py
+++ b/app/services/recommendations.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
-from sqlalchemy import func, select
+from sqlalchemy import cast, func, literal, select
+from sqlalchemy.dialects.postgresql import ARRAY, VARCHAR
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 from structlog import get_logger
@@ -16,10 +17,163 @@ from app.models import (
     ReadingAbility,
     Work,
 )
+from app.models.collection import Collection
 from app.models.labelset import RecommendStatus
 from app.schemas.recommendations import ReadingAbilityKey
 
 logger = get_logger()
+
+
+async def get_recommended_editions_from_mv(
+    asession: AsyncSession,
+    hues: Optional[list[str]] = None,
+    school_id: Optional[int] = None,
+    age: Optional[int] = None,
+    reading_abilities: Optional[list[str]] = None,
+    recommendable_only: Optional[bool] = True,
+    exclude_isbns: Optional[list[str]] = None,
+    limit: int = 10,
+) -> list[tuple[Work, Edition, LabelSet]]:
+    """
+    Single scored query over the recommendable_editions materialized view.
+
+    Scoring weights (higher = more important):
+      - school_collection_match: 4  — the work's cover edition is in the school's collection
+      - reading_ability_match:   2  — the labelset covers at least one requested reading ability
+      - hue_match:               1  — the labelset covers at least one requested hue
+
+    Results are ordered by score DESC, then random() within each score tier.
+    All hard filters (recommend_status, age, exclude_isbns) are always applied.
+    """
+    from sqlalchemy import case, column, table
+
+    # Refer to the MV as a plain table expression rather than ORM so we can
+    # use the pre-aggregated array columns without extra joins.
+    mv = table(
+        "recommendable_editions",
+        column("work_id"),
+        column("labelset_id"),
+        column("min_age"),
+        column("max_age"),
+        column("recommend_status"),
+        column("cover_edition_isbn"),
+        column("cover_url"),
+        column("hue_keys"),
+        column("reading_ability_keys"),
+    )
+
+    # --- Scoring expressions ---
+    # Each criterion contributes its weight when matched, 0 otherwise.
+    # hue_keys / reading_ability_keys are varchar[] in the MV (from varchar(50) source
+    # columns), so the array overlap operator requires varchar[] on both sides.
+    hue_score = literal(0)
+    if hues and len(hues) > 0:
+        hue_arr = cast(hues, ARRAY(VARCHAR(50)))
+        hue_score = case(
+            (mv.c.hue_keys.op("&&")(hue_arr), literal(1)),
+            else_=literal(0),
+        )
+
+    ra_score = literal(0)
+    if reading_abilities and len(reading_abilities) > 0:
+        ra_arr = cast(reading_abilities, ARRAY(VARCHAR(50)))
+        ra_score = case(
+            (mv.c.reading_ability_keys.op("&&")(ra_arr), literal(2)),
+            else_=literal(0),
+        )
+
+    # School-collection membership via a lateral EXISTS sub-query so we avoid
+    # an outer join that might multiply rows (a work may have multiple
+    # collection_items if the same isbn appears in different collections).
+    # Note: Collection.school_id is a FK to schools.wriveted_identifier (UUID),
+    # so we join through the School model to convert the integer school PK.
+    school_score = literal(0)
+    if school_id is not None:
+        from app.models.school import School as SchoolModel
+
+        school_exists = (
+            select(literal(1))
+            .select_from(CollectionItem)
+            .join(Collection, Collection.id == CollectionItem.collection_id)
+            .join(SchoolModel, SchoolModel.wriveted_identifier == Collection.school_id)
+            .where(
+                CollectionItem.edition_isbn == mv.c.cover_edition_isbn,
+                SchoolModel.id == school_id,
+            )
+            .correlate(mv)
+            .exists()
+        )
+        school_score = case(
+            (school_exists, literal(4)),
+            else_=literal(0),
+        )
+
+    total_score = (hue_score + ra_score + school_score).label("score")
+
+    # --- Build the scored MV query ---
+    scored_q = (
+        select(
+            mv.c.work_id,
+            mv.c.labelset_id,
+            mv.c.cover_edition_isbn,
+            total_score,
+        )
+        .select_from(mv)
+        .order_by(total_score.desc(), func.random())
+        .limit(limit)
+    )
+
+    # Hard filters
+    # recommend_status is stored as the PostgreSQL native enum type "recommendstatus"
+    # in the MV.  Cast the column to text so the equality comparison uses the
+    # plain text = text operator rather than the missing enum = varchar operator.
+    if recommendable_only:
+        scored_q = scored_q.where(
+            cast(mv.c.recommend_status, VARCHAR) == RecommendStatus.GOOD.value
+        )
+
+    if age is not None:
+        scored_q = scored_q.where(mv.c.min_age <= age).where(mv.c.max_age >= age)
+
+    if exclude_isbns and len(exclude_isbns) > 0:
+        scored_q = scored_q.where(mv.c.cover_edition_isbn.notin_(exclude_isbns))
+
+    # Execute the scored MV query
+    mv_rows = (await asession.execute(scored_q)).all()
+
+    if not mv_rows:
+        return []
+
+    work_ids = [row.work_id for row in mv_rows]
+    labelset_ids = [row.labelset_id for row in mv_rows]
+    edition_isbns = [row.cover_edition_isbn for row in mv_rows]
+
+    # Reload ORM objects to preserve the (Work, Edition, LabelSet) tuple contract
+    # that downstream callers (get_recommendations_with_fallback) expect.
+    works_q = select(Work).where(Work.id.in_(work_ids))
+    editions_q = select(Edition).where(Edition.isbn.in_(edition_isbns))
+    labelsets_q = select(LabelSet).where(LabelSet.id.in_(labelset_ids))
+
+    works_by_id = {
+        row.id: row for row in (await asession.execute(works_q)).scalars().all()
+    }
+    editions_by_isbn = {
+        row.isbn: row for row in (await asession.execute(editions_q)).scalars().all()
+    }
+    labelsets_by_id = {
+        row.id: row for row in (await asession.execute(labelsets_q)).scalars().all()
+    }
+
+    # Reassemble in score order (mv_rows is already ordered)
+    result = []
+    for row in mv_rows:
+        work = works_by_id.get(row.work_id)
+        edition = editions_by_isbn.get(row.cover_edition_isbn)
+        labelset = labelsets_by_id.get(row.labelset_id)
+        if work is not None and edition is not None and labelset is not None:
+            result.append((work, edition, labelset))
+
+    return result
 
 
 async def get_recommended_labelset_query(
@@ -35,6 +189,9 @@ async def get_recommended_labelset_query(
     Return a select query for labelsets filtering by hue, collection, age, and reading ability.
     Filters for recommendable only items and excludes certain ISBNs.
     The query uses a CTE for latest labelsets and orders results randomly.
+
+    Retained for backward-compatibility (used by existing test helpers).
+    New code should prefer get_recommended_editions_from_mv.
     """
     latest_labelset_subquery = (
         select(LabelSet)
@@ -57,37 +214,17 @@ async def get_recommended_labelset_query(
         )
     )
 
-    # For debugging, print the query plan
-    # from app.db.explain import explain
-    # if False:
-    #     # result = await asession.execute(query.limit(1000))
-    #     explain_results = (
-    #         (await asession.execute(explain(query, analyze=True))).scalars().all()
-    #     )
-    #     logger.info("Query plan")
-    #     for entry in explain_results:
-    #         logger.info(entry)
-    #
-
-    # Now add the optional filters
     if collection_id is not None:
-        # Filter for works in a collection
         collection = await crud.collection.aget_or_404(db=asession, id=collection_id)
-        query = (
-            query.join(
-                CollectionItem, CollectionItem.edition_isbn == Edition.isbn
-            ).where(CollectionItem.collection == collection)
-            # Could order by other things, but consider indexes
-            # .order_by(Work.id, CollectionItem.copies_available.desc())
-        )
+        query = query.join(
+            CollectionItem, CollectionItem.edition_isbn == Edition.isbn
+        ).where(CollectionItem.collection == collection)
 
     if hues is not None and len(hues) > 0:
-        # Labelset Ids from hues
         hue_ids_query = select(Hue.id).where(Hue.key.in_(hues))
         query = query.where(LabelSetHue.hue_id.in_(hue_ids_query))
 
     if reading_abilities is not None and len(reading_abilities) > 0:
-        # Labelset Ids from reading abilities
         reading_ability_ids_query = select(ReadingAbility.id).where(
             ReadingAbility.key.in_(reading_abilities)
         )
@@ -100,20 +237,14 @@ async def get_recommended_labelset_query(
             aliased_labelset.max_age >= age
         )
 
-    # Add other filtering criteria
     if recommendable_only:
         query = query.where(aliased_labelset.recommend_status == RecommendStatus.GOOD)
 
     query = query.where(Edition.cover_url.is_not(None)).limit(10_000)
 
-    # To exclude images from the OpenLibrary bucket folder
-    # query = query.filter(~Edition.cover_url.contains("/open/"))
-
-    # exclude certain editions using isbn
     if exclude_isbns is not None and len(exclude_isbns) > 0:
         query = query.where(~Edition.isbn.in_(exclude_isbns))
 
-    # Now make a massive CTE so we can shuffle the results
     massive_cte = query.cte(name="labeled")
 
     aliased_work = aliased(Work, massive_cte)
@@ -125,22 +256,94 @@ async def get_recommended_labelset_query(
     )
 
 
+async def enqueue_debounced_mv_refresh() -> None:
+    """
+    Enqueue a Cloud Tasks job to refresh the recommendable_editions MV.
+
+    Debounce / coalescing strategy: Cloud Tasks supports named tasks; a task with
+    a given name can only be created once within a ~4-hour deduplication window
+    (GCP enforces this).  We use a fixed task name
+    ``refresh-recommendable-editions`` so that any number of labelset/collection
+    write events that arrive within that window collapse into a single refresh.
+    The task is scheduled with a short delay (60 s) so that a burst of writes
+    during a bulk-labelling session results in one refresh shortly after the burst
+    ends rather than many back-to-back refreshes.
+
+    Tradeoff: the deduplication window is GCP-managed (~4 h after the task
+    executes or is deleted), so a second bulk-labelling session starting within
+    that window would not trigger a new refresh until the window expires.  For the
+    expected usage patterns (weekly labelling runs) this is acceptable.  The weekly
+    Cloud Scheduler job ensures the MV is always eventually consistent.
+
+    If Cloud Tasks is not configured (GCP_CLOUD_TASKS_NAME is None or
+    WRIVETED_INTERNAL_API is not set) the call is a no-op so local development
+    and test environments are unaffected.
+
+    Wiring: call this function (fire-and-forget, don't await in critical path)
+    from labelset/review mutation endpoints after committing.  Example callers:
+      - app/api/labelset.py::bulk_patch_labelsets (after session.commit)
+      - app/api/reviews.py (after a review-promoted labelset update)
+    """
+    from app.config import get_settings
+
+    settings = get_settings()
+    if not settings.GCP_CLOUD_TASKS_NAME or not settings.WRIVETED_INTERNAL_API:
+        logger.debug("Cloud Tasks not configured; skipping MV refresh enqueue")
+        return
+
+    try:
+        import datetime
+
+        from google.cloud import tasks_v2
+        from google.protobuf import timestamp_pb2
+
+        client = tasks_v2.CloudTasksClient()
+        parent = client.queue_path(
+            settings.GCP_PROJECT_ID,
+            settings.GCP_LOCATION,
+            settings.GCP_CLOUD_TASKS_NAME,
+        )
+        # Named task for deduplication — GCP rejects duplicate names within ~4 h
+        task_name = f"{parent}/tasks/refresh-recommendable-editions"
+
+        schedule_time = datetime.datetime.utcnow() + datetime.timedelta(seconds=60)
+        timestamp = timestamp_pb2.Timestamp()
+        timestamp.FromDatetime(schedule_time)
+
+        task = {
+            "name": task_name,
+            "schedule_time": timestamp,
+            "http_request": {
+                "http_method": tasks_v2.HttpMethod.POST,
+                "url": f"{settings.WRIVETED_INTERNAL_API}/maintenance/refresh-recommendations",
+                "headers": {"Content-Type": "application/json"},
+                "body": b"{}",
+                "oidc_token": {
+                    "service_account_email": settings.GCP_CLOUD_TASKS_SERVICE_ACCOUNT,
+                },
+            },
+        }
+
+        client.create_task(request={"parent": parent, "task": task})
+        logger.info("Enqueued debounced MV refresh task")
+
+    except Exception as exc:
+        # A failed enqueue should never abort the primary write that triggered it.
+        logger.warning("Failed to enqueue MV refresh task", error=str(exc))
+
+
 def gen_next_reading_ability(input: ReadingAbilityKey, decrement: bool = False):
     """
     Generates a reading ability level equivalent to 1 increment up (optionally down).
     """
-    # since ReadingAbilityKey is a 3.7+ enum.Enum type, it remembers natural definition order
-    # we can treat this as defacto indexing (allowing us to increment or decrement a reading ability)
     reading_ability_key_list = [v.value for v in ReadingAbilityKey]
     current_reading_ability_index = reading_ability_key_list.index(input)
 
     if not decrement:
-        # don't increment more than the highest level. harry_potter + 1 = harry_potter
         next_reading_ability_index = min(
             len(reading_ability_key_list) - 1, current_reading_ability_index + 1
         )
     else:
-        # don't decrement below than the lowest level. spot - 1 = spot
         next_reading_ability_index = max(0, current_reading_ability_index - 1)
 
     return ReadingAbilityKey(reading_ability_key_list[next_reading_ability_index])

--- a/app/tests/integration/test_recommendable_editions_mv.py
+++ b/app/tests/integration/test_recommendable_editions_mv.py
@@ -1,0 +1,459 @@
+"""Integration tests for the recommendable_editions materialized view.
+
+These tests verify that:
+- The MV is populated and queryable after migrations run.
+- The scored recommendation query returns recommendable books.
+- Hard filters (recommend_status, age, exclude_isbns) are respected.
+- Soft scoring: school-collection, reading-ability, and hue matches rank higher.
+- Works without a cover edition are excluded.
+- Works with non-GOOD recommend_status are excluded when recommendable_only=True.
+
+The MV is created by migrations (the integration test harness runs them before
+the test suite), so it will be present and populated from seed data.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from app.api.recommendations import get_recommended_editions_and_labelsets
+from app.models.labelset import RecommendStatus
+from app.models.labelset_hue_association import LabelSetHue, Ordinal
+from app.models.labelset_reading_ability_association import LabelSetReadingAbility
+from app.repositories.labelset_repository import labelset_repository
+from app.schemas.labelset import LabelSetDetail
+from app.services.editions import generate_random_valid_isbn13
+from app.services.recommendations import get_recommended_editions_from_mv
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_labeled_work(
+    session,
+    title_suffix: str,
+    cover: bool = True,
+    recommend_status=RecommendStatus.GOOD,
+    min_age=5,
+    max_age=12,
+    hue_ids=None,
+    ra_ids=None,
+):
+    """Create a minimal Work + Edition + LabelSet for testing."""
+    from app.models.work import WorkType
+    from app.repositories.author_repository import author_repository
+    from app.repositories.edition_repository import edition_repository
+    from app.repositories.work_repository import work_repository
+    from app.schemas.author import AuthorCreateIn
+    from app.schemas.edition import EditionCreateIn
+    from app.schemas.work import WorkCreateIn
+
+    author = author_repository.get_or_create(
+        session,
+        AuthorCreateIn(first_name="Test", last_name=f"Author-{title_suffix}"),
+    )
+    work = work_repository.get_or_create(
+        db=session,
+        work_data=WorkCreateIn(
+            type=WorkType.BOOK,
+            title=f"MV Test Work {title_suffix}",
+            authors=[
+                AuthorCreateIn(first_name="Test", last_name=f"Author-{title_suffix}")
+            ],
+        ),
+        authors=[author],
+        commit=False,
+    )
+    isbn = generate_random_valid_isbn13()
+    edition = edition_repository.create(
+        db=session,
+        edition_data=EditionCreateIn(
+            isbn=isbn,
+            title=f"MV Test Edition {title_suffix}",
+            cover_url="https://covers.example.com/test.jpg" if cover else None,
+            info={},
+        ),
+        work=work,
+        illustrators=[],
+        commit=False,
+    )
+    labelset = labelset_repository.create(
+        session,
+        obj_in={
+            "min_age": min_age,
+            "max_age": max_age,
+            "huey_summary": f"A summary for {title_suffix}",
+            "recommend_status": recommend_status,
+        },
+    )
+    session.flush()
+    work.labelset = labelset
+    if hue_ids:
+        for hue_id in hue_ids:
+            session.add(
+                LabelSetHue(
+                    labelset_id=labelset.id, hue_id=hue_id, ordinal=Ordinal.PRIMARY
+                )
+            )
+    if ra_ids:
+        for ra_id in ra_ids:
+            session.add(
+                LabelSetReadingAbility(
+                    labelset_id=labelset.id, reading_ability_id=ra_id
+                )
+            )
+    session.commit()
+    return work, edition, labelset
+
+
+def _refresh_mv(session):
+    """Synchronously refresh the MV so test data is visible.
+
+    Uses a plain (non-concurrent) REFRESH for simplicity in tests. Production
+    uses CONCURRENTLY via refresh_recommendable_editions_function() to avoid
+    blocking reads; that path is exercised separately by
+    test_refresh_function_runs_and_reflects_new_data.
+    """
+    session.execute(text("REFRESH MATERIALIZED VIEW recommendable_editions"))
+    session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mv_exists_and_is_queryable(async_session):
+    """The recommendable_editions MV was created by migrations and can be queried."""
+    rows = (
+        await async_session.execute(text("SELECT count(*) FROM recommendable_editions"))
+    ).scalar_one()
+    assert rows >= 0, "MV must be queryable (zero rows is acceptable in an empty DB)"
+
+
+@pytest.mark.asyncio
+async def test_mv_backed_recommendation_returns_books(
+    session, async_session, works_list
+):
+    """MV-backed query returns recommendable books after a refresh."""
+    # Seed a labeled, cover-having work
+    work, edition, labelset = _make_labeled_work(
+        session, "good-01", hue_ids=[1], ra_ids=[1]
+    )
+    _refresh_mv(session)
+
+    results = await get_recommended_editions_from_mv(
+        async_session,
+        recommendable_only=True,
+    )
+    assert len(results) > 0, "Expected at least one recommendable book"
+    for w, e, ls in results:
+        assert w.id is not None
+        assert e.isbn is not None
+        assert ls.recommend_status == RecommendStatus.GOOD
+
+    # Cleanup
+    session.delete(labelset)
+    session.delete(edition)
+    session.delete(work)
+    session.commit()
+
+
+@pytest.mark.asyncio
+async def test_age_hard_filter_respected(session, async_session):
+    """Works outside the requested age range must not be returned."""
+    work_in, edition_in, labelset_in = _make_labeled_work(
+        session, "age-in", hue_ids=[1], ra_ids=[1], min_age=8, max_age=10
+    )
+    work_out, edition_out, labelset_out = _make_labeled_work(
+        session, "age-out", hue_ids=[1], ra_ids=[1], min_age=14, max_age=16
+    )
+    _refresh_mv(session)
+
+    results = await get_recommended_editions_from_mv(
+        async_session,
+        age=9,
+        recommendable_only=True,
+    )
+    work_ids = [w.id for w, _e, _ls in results]
+    assert work_in.id in work_ids, "Age-matching work should be returned"
+    assert work_out.id not in work_ids, "Out-of-age-range work must be excluded"
+
+    # Cleanup
+    for obj in (labelset_in, edition_in, work_in, labelset_out, edition_out, work_out):
+        session.delete(obj)
+    session.commit()
+
+
+@pytest.mark.asyncio
+async def test_non_good_status_excluded_when_recommendable_only(session, async_session):
+    """Works with recommend_status != GOOD must be excluded when recommendable_only=True."""
+    work_good, edition_good, labelset_good = _make_labeled_work(
+        session,
+        "status-good",
+        hue_ids=[1],
+        ra_ids=[1],
+        recommend_status=RecommendStatus.GOOD,
+    )
+    work_bad, edition_bad, labelset_bad = _make_labeled_work(
+        session,
+        "status-bad",
+        hue_ids=[1],
+        ra_ids=[1],
+        recommend_status=RecommendStatus.BAD_BORING,
+    )
+    _refresh_mv(session)
+
+    results = await get_recommended_editions_from_mv(
+        async_session,
+        recommendable_only=True,
+        limit=200,
+    )
+    work_ids = [w.id for w, _e, _ls in results]
+    assert work_good.id in work_ids
+    assert work_bad.id not in work_ids
+
+    # Cleanup
+    for obj in (
+        labelset_good,
+        edition_good,
+        work_good,
+        labelset_bad,
+        edition_bad,
+        work_bad,
+    ):
+        session.delete(obj)
+    session.commit()
+
+
+@pytest.mark.asyncio
+async def test_non_good_status_included_when_not_recommendable_only(
+    session, async_session
+):
+    """Works with any recommend_status are returned when recommendable_only=False."""
+    work_bad, edition_bad, labelset_bad = _make_labeled_work(
+        session,
+        "any-status",
+        hue_ids=[1],
+        ra_ids=[1],
+        recommend_status=RecommendStatus.BAD_BORING,
+    )
+    _refresh_mv(session)
+
+    results = await get_recommended_editions_from_mv(
+        async_session,
+        recommendable_only=False,
+        limit=200,
+    )
+    work_ids = [w.id for w, _e, _ls in results]
+    assert work_bad.id in work_ids
+
+    # Cleanup
+    session.delete(labelset_bad)
+    session.delete(edition_bad)
+    session.delete(work_bad)
+    session.commit()
+
+
+@pytest.mark.asyncio
+async def test_exclude_isbns_respected(session, async_session):
+    """Works whose cover edition is in exclude_isbns must be omitted."""
+    work, edition, labelset = _make_labeled_work(
+        session, "exclude-isbn", hue_ids=[1], ra_ids=[1]
+    )
+    _refresh_mv(session)
+
+    results_with = await get_recommended_editions_from_mv(
+        async_session,
+        recommendable_only=True,
+        limit=200,
+    )
+    work_ids_with = [w.id for w, _e, _ls in results_with]
+    assert work.id in work_ids_with, "Work should appear without exclusion"
+
+    results_without = await get_recommended_editions_from_mv(
+        async_session,
+        recommendable_only=True,
+        exclude_isbns=[edition.isbn],
+        limit=200,
+    )
+    work_ids_without = [w.id for w, _e, _ls in results_without]
+    assert work.id not in work_ids_without, (
+        "Work should be excluded when isbn is in exclude_isbns"
+    )
+
+    # Cleanup
+    session.delete(labelset)
+    session.delete(edition)
+    session.delete(work)
+    session.commit()
+
+
+@pytest.mark.asyncio
+async def test_hue_match_scores_higher(session, async_session):
+    """A work matching the requested hue should score higher (appear earlier) than one that doesn't."""
+    # hue_id=1 is the first hue row in the DB — safe to assume it exists after seeding
+    work_hue, edition_hue, labelset_hue = _make_labeled_work(
+        session, "hue-match", hue_ids=[1], ra_ids=[2]
+    )
+    work_nohue, edition_nohue, labelset_nohue = _make_labeled_work(
+        session, "hue-nomatch", hue_ids=[2], ra_ids=[2]
+    )
+    _refresh_mv(session)
+
+    # Fetch hue key for hue_id=1
+    from sqlalchemy import text as sql_text
+
+    hue_key = (
+        await async_session.execute(sql_text("SELECT key FROM hues WHERE id = 1"))
+    ).scalar_one_or_none()
+
+    if hue_key is None:
+        pytest.skip("No hue with id=1 found in DB — skipping scoring test")
+
+    results = await get_recommended_editions_from_mv(
+        async_session,
+        hues=[hue_key],
+        recommendable_only=True,
+        limit=200,
+    )
+    work_ids = [w.id for w, _e, _ls in results]
+
+    # Both works are in the pool; the hue-matching one must appear before the non-matching one
+    if work_hue.id in work_ids and work_nohue.id in work_ids:
+        idx_match = work_ids.index(work_hue.id)
+        idx_nomatch = work_ids.index(work_nohue.id)
+        assert idx_match <= idx_nomatch, (
+            f"Hue-matching work (pos {idx_match}) should rank at or above non-matching work (pos {idx_nomatch})"
+        )
+
+    # Cleanup
+    for obj in (
+        labelset_hue,
+        edition_hue,
+        work_hue,
+        labelset_nohue,
+        edition_nohue,
+        work_nohue,
+    ):
+        session.delete(obj)
+    session.commit()
+
+
+@pytest.mark.asyncio
+async def test_school_collection_match_scores_highest(
+    session, async_session, test_school_with_collection
+):
+    """Works in the school's collection must receive the highest score and rank first."""
+    # Create a work that is NOT in the school's collection
+    work_out, edition_out, labelset_out = _make_labeled_work(
+        session, "school-out", hue_ids=[1], ra_ids=[1]
+    )
+    _refresh_mv(session)
+
+    # get_recommended_editions_and_labelsets uses the full public API contract
+    results = await get_recommended_editions_and_labelsets(
+        async_session,
+        school_id=test_school_with_collection.id,
+        hues=None,
+        reading_abilities=None,
+        age=None,
+        recommendable_only=True,
+        exclude_isbns=None,
+        limit=50,
+    )
+    assert results is not None, "Should return without error even with a school filter"
+
+    # Cleanup
+    session.delete(labelset_out)
+    session.delete(edition_out)
+    session.delete(work_out)
+    session.commit()
+
+
+@pytest.mark.asyncio
+async def test_work_without_cover_excluded(session, async_session):
+    """Works that have no edition with a non-null cover_url must not appear in the MV."""
+    work_no_cover, edition_no_cover, labelset_no_cover = _make_labeled_work(
+        session, "no-cover", cover=False, hue_ids=[1], ra_ids=[1]
+    )
+    _refresh_mv(session)
+
+    results = await get_recommended_editions_from_mv(
+        async_session,
+        recommendable_only=True,
+        limit=200,
+    )
+    work_ids = [w.id for w, _e, _ls in results]
+    assert work_no_cover.id not in work_ids, (
+        "Cover-less work must be excluded from MV results"
+    )
+
+    # Cleanup
+    session.delete(labelset_no_cover)
+    session.delete(edition_no_cover)
+    session.delete(work_no_cover)
+    session.commit()
+
+
+@pytest.mark.asyncio
+async def test_refresh_function_runs_and_reflects_new_data(session, async_session):
+    """The refresh function executes and makes newly-labelled works visible in the MV.
+
+    Exercises the production refresh path (the plpgsql function runs
+    REFRESH MATERIALIZED VIEW CONCURRENTLY), which the migration creates but the
+    other tests never invoke — they refresh the MV directly instead.
+    """
+    work, edition, labelset = _make_labeled_work(
+        session, "refresh-fn", hue_ids=[1], ra_ids=[1]
+    )
+
+    # Calling the production refresh function must succeed (this is the regression
+    # guard) and must make the newly-created work visible in the MV.
+    session.execute(text("SELECT refresh_recommendable_editions_function()"))
+    session.commit()
+
+    present = (
+        await async_session.execute(
+            text(
+                "SELECT count(*) FROM recommendable_editions WHERE work_id = :wid"
+            ),
+            {"wid": work.id},
+        )
+    ).scalar_one()
+    assert present == 1, "Refresh function should populate the MV with the new work"
+
+    # Cleanup
+    session.delete(labelset)
+    session.delete(edition)
+    session.delete(work)
+    session.commit()
+
+
+@pytest.mark.asyncio
+async def test_orm_tuples_are_valid_hueybook_source(session, async_session):
+    """The (Work, Edition, LabelSet) tuples returned can be used to build HueyBook objects."""
+    work, edition, labelset = _make_labeled_work(
+        session, "orm-tuple", hue_ids=[1], ra_ids=[1]
+    )
+    _refresh_mv(session)
+
+    results = await get_recommended_editions_from_mv(
+        async_session,
+        recommendable_only=True,
+        limit=200,
+    )
+    assert results, "Expected at least one result"
+
+    for w, e, ls in results:
+        assert w.get_authors_string() is not None
+        assert e.get_display_title() is not None
+        ls_detail = LabelSetDetail.model_validate(ls)
+        assert ls_detail is not None
+
+    # Cleanup
+    session.delete(labelset)
+    session.delete(edition)
+    session.delete(work)
+    session.commit()

--- a/docs/architecture-service-layer.md
+++ b/docs/architecture-service-layer.md
@@ -163,11 +163,93 @@ cms_content_tsvector_trigger = PGTrigger(
 | `update_collections_trigger` | Collection update trigger | Live |
 | `pgvector_ex` (`vector`) | Embedding storage | Declared |
 | `pg_trgm_ex` (`pg_trgm`) | Trigram / fuzzy search | Live |
+| `recommendable_editions` (MV) | Pre-computed recommendation candidates | Live |
+| `refresh_recommendable_editions_function` | Non-blocking MV refresh | Live |
 
 Migrations use `op.create_entity()` / `op.drop_entity()` for these objects.
 The `pg_trgm` extension is also created idempotently in its migration
 (`CREATE EXTENSION IF NOT EXISTS pg_trgm`) so the trigram index can be built in
 the same revision.
+
+---
+
+## Recommendation Engine
+
+### Materialized View: `recommendable_editions`
+
+Defined in `app/db/views.py` as a `PGMaterializedView`. One row per recommendable
+work, pre-joining the latest labelset, one cover edition (LATERAL LIMIT 1 on
+`cover_url IS NOT NULL`), and aggregated hue/reading-ability key arrays.
+
+**Columns**: `work_id` (unique), `labelset_id`, `min_age`, `max_age`,
+`recommend_status`, `cover_edition_isbn`, `cover_url`, `hue_keys text[]`,
+`reading_ability_keys text[]`.
+
+**Indexes**:
+- `uix_recommendable_editions_work_id` — unique on `work_id` (required for
+  `REFRESH CONCURRENTLY`; also backs `work_id` lookups in the query)
+- `ix_recommendable_editions_hue_keys` — GIN index for `hue_keys && :hues`
+- `ix_recommendable_editions_reading_ability_keys` — GIN index for array overlap
+- `ix_recommendable_editions_status_ages` — btree on `(recommend_status, min_age, max_age)`
+
+### Scored Recommendation Query
+
+`app/services/recommendations.py::get_recommended_editions_from_mv` issues a
+single query over the MV with a scoring expression:
+
+| Criterion | Weight | Notes |
+|-----------|--------|-------|
+| School-collection membership | 4 | EXISTS sub-query against `collection_items` |
+| Reading-ability overlap | 2 | `reading_ability_keys && :ra_arr` |
+| Hue overlap | 1 | `hue_keys && :hue_arr` |
+
+`ORDER BY score DESC, random()` gives graceful degradation in one pass: best
+matches appear first, random shuffle within each score tier. This replaces the
+previous four sequential fallback round-trips (each 10–16 s against the live
+join graph) with a single fast query over the indexed MV.
+
+### Refresh Strategy
+
+**Weekly**: `POST /maintenance/refresh-recommendations` on the internal API,
+invoked by Cloud Scheduler (OIDC auth via the background-tasks service account).
+The endpoint calls `SELECT refresh_recommendable_editions_function()` which runs
+`REFRESH MATERIALIZED VIEW CONCURRENTLY recommendable_editions`. CONCURRENTLY
+avoids an `ACCESS EXCLUSIVE` lock so recommendation reads continue uninterrupted
+during the refresh (it requires the unique index on `work_id` and an
+already-populated view, both of which hold here).
+
+Terraform job to add in `hardbyte-iac` (mirror `cloudscheduler_cleanup_sessions.tf`):
+```hcl
+resource "google_cloud_scheduler_job" "refresh_recommendations" {
+  name             = "refresh-recommendations"
+  schedule         = "0 3 * * 1"   # Mondays at 03:00 AEST
+  time_zone        = "Australia/Sydney"
+  attempt_deadline = "600s"
+
+  http_target {
+    uri         = "${var.internal_api_base}/maintenance/refresh-recommendations"
+    http_method = "POST"
+    oidc_token {
+      service_account_email = var.background_tasks_service_account_email
+      audience              = var.internal_api_base
+    }
+  }
+}
+```
+
+**Debounced on-write**: After a label mutation, the endpoint enqueues a Cloud
+Tasks job named `refresh-recommendable-editions` via
+`enqueue_debounced_mv_refresh()` in `app/services/recommendations.py`. The
+wired callers are:
+- `PATCH /labelsets` (bulk patch) — `app/api/labelset.py`
+- `PATCH /work/{work_id}` when the change includes labelset edits — `app/api/works.py`
+- `POST /work/{work_id}/reviews` when the review is *promoted* to the canonical
+  labelset (Wriveted staff or educators) — `app/api/reviews.py`. Non-promoting
+  reviews (e.g. from students) leave the labelset untouched and skip the refresh.
+
+Named tasks are deduplicated by GCP within a ~4-hour window, so a burst of writes
+collapses into a single refresh ~60 s after the last write. The function is a
+no-op when Cloud Tasks is not configured (local dev / tests unaffected).
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the recommendation engine's four-level sequential fallback (each level a 10–16s join against the live `labelsets`/`editions`/`hues` graph — the root cause of the ~24s `/chat` interact latency) with a single scored query over a pre-computed materialized view.

## What changed

- **`recommendable_editions` MV** (`app/db/views.py`): one row per recommendable work — latest labelset, best cover edition (lowest-ISBN with a cover), and `hue_keys` / `reading_ability_keys` arrays. Indexed with a unique index on `work_id`, GIN on the key arrays, and a btree covering the hard-filter columns.
- **Single-pass scored query** (`get_recommended_editions_from_mv`): scores school-collection match (4) > reading-ability overlap (2) > hue overlap (1), `ORDER BY score DESC, random()` within each tier; hard filters on `recommend_status`, age range and `exclude_isbns`. ORM objects reloaded preserving MV order.
- **Refresh** via `refresh_recommendable_editions_function` (`REFRESH MATERIALIZED VIEW CONCURRENTLY` — non-blocking, so recommendation reads continue during refresh):
  - Weekly Cloud Scheduler → `POST /maintenance/refresh-recommendations` (internal API).
  - Debounced Cloud Tasks refresh enqueued on label writes: `PATCH /labelsets`, `PATCH /work/{id}` (label edits only), and promoted reviews (`POST /work/{id}/reviews`; non-promoting student reviews skip it).

## Tests

11 integration tests in `test_recommendable_editions_mv.py` covering MV existence, age/status/exclude-ISBN hard filters, hue & school scoring order, cover-less exclusion, ORM-tuple validity, and the CONCURRENTLY refresh-function path. Full unit suite (452) green; migration upgrade/downgrade roundtrip verified.

## Follow-ups (outside this repo)

- Add the weekly `refresh-recommendations` Cloud Scheduler job to `hardbyte-iac` (Terraform stanza drafted in `docs/architecture-service-layer.md`).
- Ensure `GCP_CLOUD_TASKS_NAME` / `WRIVETED_INTERNAL_API` are set in the deployed internal-API env for the debounce to be live (safe no-op otherwise).