### PR TITLE
Fix debounced MV refresh task URL (missing /v1 prefix)

### DIFF
--- a/app/services/recommendations.py
+++ b/app/services/recommendations.py
@@ -315,7 +315,7 @@ async def enqueue_debounced_mv_refresh() -> None:
             "schedule_time": timestamp,
             "http_request": {
                 "http_method": tasks_v2.HttpMethod.POST,
-                "url": f"{settings.WRIVETED_INTERNAL_API}/maintenance/refresh-recommendations",
+                "url": f"{settings.WRIVETED_INTERNAL_API}/v1/maintenance/refresh-recommendations",
                 "headers": {"Content-Type": "application/json"},
                 "body": b"{}",
                 "oidc_token": {

--- a/app/tests/unit/test_mv_refresh_enqueue.py
+++ b/app/tests/unit/test_mv_refresh_enqueue.py
@@ -1,0 +1,71 @@
+"""Unit tests for enqueue_debounced_mv_refresh.
+
+Guards the Cloud Tasks target URL: the internal API router is mounted under
+API_V1_STR (/v1), so the refresh endpoint lives at
+/v1/maintenance/refresh-recommendations. A task posted to
+/maintenance/refresh-recommendations (no /v1) 404s and the debounced on-write
+refresh silently never runs.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services import recommendations
+
+
+@pytest.mark.asyncio
+async def test_enqueue_targets_v1_refresh_endpoint(monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        def queue_path(self, project, location, queue):
+            return f"projects/{project}/locations/{location}/queues/{queue}"
+
+        def create_task(self, request):
+            captured["task"] = request["task"]
+
+    fake_settings = SimpleNamespace(
+        GCP_CLOUD_TASKS_NAME="background-tasks",
+        WRIVETED_INTERNAL_API="https://internal.example.run.app",
+        GCP_PROJECT_ID="wriveted-api",
+        GCP_LOCATION="australia-southeast1",
+        GCP_CLOUD_TASKS_SERVICE_ACCOUNT="background-tasks@wriveted-api.iam.gserviceaccount.com",
+    )
+    monkeypatch.setattr(
+        "app.config.get_settings", lambda: fake_settings, raising=True
+    )
+
+    from google.cloud import tasks_v2
+
+    monkeypatch.setattr(tasks_v2, "CloudTasksClient", lambda: FakeClient())
+
+    await recommendations.enqueue_debounced_mv_refresh()
+
+    url = captured["task"]["http_request"]["url"]
+    assert url == (
+        "https://internal.example.run.app/v1/maintenance/refresh-recommendations"
+    )
+    assert url.endswith("/v1/maintenance/refresh-recommendations")
+
+
+@pytest.mark.asyncio
+async def test_enqueue_is_noop_when_cloud_tasks_unconfigured(monkeypatch):
+    """No Cloud Tasks queue configured (local/dev/test) → no client constructed."""
+    fake_settings = SimpleNamespace(
+        GCP_CLOUD_TASKS_NAME=None,
+        WRIVETED_INTERNAL_API="https://internal.example.run.app",
+    )
+    monkeypatch.setattr(
+        "app.config.get_settings", lambda: fake_settings, raising=True
+    )
+
+    from google.cloud import tasks_v2
+
+    boom = MagicMock(side_effect=AssertionError("client must not be constructed"))
+    monkeypatch.setattr(tasks_v2, "CloudTasksClient", boom)
+
+    # Should return cleanly without touching Cloud Tasks.
+    await recommendations.enqueue_debounced_mv_refresh()
+    boom.assert_not_called()


### PR DESCRIPTION
## Summary

Follow-up to #664. The debounced on-write refresh of `recommendable_editions` was posting its Cloud Task to the wrong path and silently 404ing.

`enqueue_debounced_mv_refresh` built the target as `{WRIVETED_INTERNAL_API}/maintenance/refresh-recommendations`, but the internal API router is mounted under `API_V1_STR` (`/v1`) — the endpoint is actually at `/v1/maintenance/refresh-recommendations`. `WRIVETED_INTERNAL_API` has no trailing slash in prod, so the task hit `/maintenance/...` and 404'd.

**Impact:** the *on-write* refresh (after label edits / promoted reviews) never ran, so freshly labelled works wouldn't surface in recommendations until the next refresh. The **weekly Cloud Scheduler** job was unaffected — it already targets the correct `/v1/...` path (hardbyte-iac), so the MV was still eventually consistent.

## Change

- One-line fix: target `/v1/maintenance/refresh-recommendations`.
- Two unit tests: assert the enqueued task URL is the `/v1` endpoint, and that the enqueue is a no-op when Cloud Tasks isn't configured (local/dev/test).

## Validation

- Full unit suite: 454 pass. `ruff` clean.

Found while verifying the deployed env (`GCP_CLOUD_TASKS_NAME` / `WRIVETED_INTERNAL_API` are both set on the public service, so this path is live — which is exactly why the bad URL mattered).