### PR TITLE
Hotfix: MV refresh enqueue blocks event loop (breaks login during labelling)

### DIFF
--- a/app/services/recommendations.py
+++ b/app/services/recommendations.py
@@ -256,9 +256,18 @@ async def get_recommended_labelset_query(
     )
 
 
-async def enqueue_debounced_mv_refresh() -> None:
+def enqueue_debounced_mv_refresh() -> None:
     """
     Enqueue a Cloud Tasks job to refresh the recommendable_editions MV.
+
+    This is a *synchronous* function on purpose. It performs blocking gRPC calls
+    (CloudTasksClient construction + create_task). When passed to
+    BackgroundTasks.add_task, Starlette runs sync background tasks in a worker
+    thread, so the blocking I/O never touches the asyncio event loop. An
+    ``async def`` version would block the single shared event loop for the
+    duration of the gRPC call, stalling every other concurrent request on the
+    instance (containerConcurrency=20) — observed as multi-second/-minute
+    latencies on unrelated endpoints such as /auth/me during a labelling burst.
 
     Debounce / coalescing strategy: Cloud Tasks supports named tasks; a task with
     a given name can only be created once within a ~4-hour deduplication window

--- a/app/tests/unit/test_mv_refresh_enqueue.py
+++ b/app/tests/unit/test_mv_refresh_enqueue.py
@@ -1,22 +1,32 @@
 """Unit tests for enqueue_debounced_mv_refresh.
 
-Guards the Cloud Tasks target URL: the internal API router is mounted under
-API_V1_STR (/v1), so the refresh endpoint lives at
-/v1/maintenance/refresh-recommendations. A task posted to
-/maintenance/refresh-recommendations (no /v1) 404s and the debounced on-write
-refresh silently never runs.
+Guards two things:
+- The Cloud Tasks target URL: the internal API router is mounted under
+  API_V1_STR (/v1), so the refresh endpoint lives at
+  /v1/maintenance/refresh-recommendations. A task posted to
+  /maintenance/refresh-recommendations (no /v1) 404s and the debounced on-write
+  refresh silently never runs.
+- That the function stays *synchronous*. It does blocking gRPC I/O, so it must
+  run in Starlette's threadpool (sync background task), not on the asyncio event
+  loop. An async version blocks the single shared event loop and stalls every
+  concurrent request on the instance (containerConcurrency=20).
 """
 
+import inspect
 from types import SimpleNamespace
 from unittest.mock import MagicMock
-
-import pytest
 
 from app.services import recommendations
 
 
-@pytest.mark.asyncio
-async def test_enqueue_targets_v1_refresh_endpoint(monkeypatch):
+def test_enqueue_is_synchronous_not_a_coroutine():
+    """Must be a plain def so BackgroundTasks runs it off the event loop."""
+    assert not inspect.iscoroutinefunction(
+        recommendations.enqueue_debounced_mv_refresh
+    ), "enqueue_debounced_mv_refresh must stay sync (blocking gRPC) so it runs in a threadpool"
+
+
+def test_enqueue_targets_v1_refresh_endpoint(monkeypatch):
     captured = {}
 
     class FakeClient:
@@ -33,15 +43,13 @@ async def test_enqueue_targets_v1_refresh_endpoint(monkeypatch):
         GCP_LOCATION="australia-southeast1",
         GCP_CLOUD_TASKS_SERVICE_ACCOUNT="background-tasks@wriveted-api.iam.gserviceaccount.com",
     )
-    monkeypatch.setattr(
-        "app.config.get_settings", lambda: fake_settings, raising=True
-    )
+    monkeypatch.setattr("app.config.get_settings", lambda: fake_settings, raising=True)
 
     from google.cloud import tasks_v2
 
     monkeypatch.setattr(tasks_v2, "CloudTasksClient", lambda: FakeClient())
 
-    await recommendations.enqueue_debounced_mv_refresh()
+    recommendations.enqueue_debounced_mv_refresh()
 
     url = captured["task"]["http_request"]["url"]
     assert url == (
@@ -50,22 +58,18 @@ async def test_enqueue_targets_v1_refresh_endpoint(monkeypatch):
     assert url.endswith("/v1/maintenance/refresh-recommendations")
 
 
-@pytest.mark.asyncio
-async def test_enqueue_is_noop_when_cloud_tasks_unconfigured(monkeypatch):
+def test_enqueue_is_noop_when_cloud_tasks_unconfigured(monkeypatch):
     """No Cloud Tasks queue configured (local/dev/test) → no client constructed."""
     fake_settings = SimpleNamespace(
         GCP_CLOUD_TASKS_NAME=None,
         WRIVETED_INTERNAL_API="https://internal.example.run.app",
     )
-    monkeypatch.setattr(
-        "app.config.get_settings", lambda: fake_settings, raising=True
-    )
+    monkeypatch.setattr("app.config.get_settings", lambda: fake_settings, raising=True)
 
     from google.cloud import tasks_v2
 
     boom = MagicMock(side_effect=AssertionError("client must not be constructed"))
     monkeypatch.setattr(tasks_v2, "CloudTasksClient", boom)
 
-    # Should return cleanly without touching Cloud Tasks.
-    await recommendations.enqueue_debounced_mv_refresh()
+    recommendations.enqueue_debounced_mv_refresh()
     boom.assert_not_called()


### PR DESCRIPTION
## Problem (production incident)

Login was failing in prod. Diagnosis: **systemic event-loop stalls**, not an auth bug.

`/v1/auth/me` was taking **52–120s (some 504s)** during a label-editing session on work 3881, while other requests at the same time were fast (~0.1s), then `/auth/me` snapped back to **0.02s** the moment the labelling burst ended. Classic single-event-loop blocking.

## Root cause

`enqueue_debounced_mv_refresh` (added in #664) was an `async def` performing **blocking gRPC calls** (`CloudTasksClient()` construction + `create_task`) directly on the asyncio event loop. It runs as a `BackgroundTask` on the label-write endpoints (`PATCH /work/{id}`, `PATCH /labelsets`, promoted reviews). With `containerConcurrency=20` (one shared event loop per instance), that blocking call stalled **every concurrent request on the instance** — including `/auth/me`, breaking login.

## Fix

Make `enqueue_debounced_mv_refresh` a plain `def`. Starlette runs sync background tasks in a worker thread, so the blocking gRPC never touches the event loop. All callers use `background_tasks.add_task` (supports sync callables); nothing awaits it.

Added a regression test asserting the function stays synchronous (`not inspect.iscoroutinefunction`).

## Validation

- Updated/added unit tests pass; `ruff` clean. Full suite + integration in CI.