### PR TITLE
Custom KPI endpoints (replaces Metabase dashboard)

### DIFF
--- a/app/api/external_api_router.py
+++ b/app/api/external_api_router.py
@@ -19,6 +19,7 @@ from app.api.editions import router as edition_router
 from app.api.events import router as events_router
 from app.api.hydration import router as hydration_router
 from app.api.illustrators import router as illustrator_router
+from app.api.kpis import router as kpis_router
 from app.api.labelset import router as labelset_router
 from app.api.onboarding import router as onboarding_router
 from app.api.recommendations import router as recommendations_router
@@ -56,6 +57,7 @@ api_router.include_router(edition_router)
 api_router.include_router(events_router)
 api_router.include_router(hydration_router)
 api_router.include_router(illustrator_router)
+api_router.include_router(kpis_router)
 api_router.include_router(labelset_router)
 api_router.include_router(onboarding_router)
 api_router.include_router(school_router)

--- a/app/api/kpis.py
+++ b/app/api/kpis.py
@@ -1,0 +1,160 @@
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from app.api.dependencies.async_db_dep import get_async_session
+from app.api.dependencies.security import (
+    get_current_active_superuser_or_backend_service_account,
+)
+from app.models.cms import ConversationSession, SessionStatus
+from app.models.collection_item_activity import (
+    CollectionItemActivity,
+    CollectionItemReadStatus,
+)
+from app.models.educator import Educator
+from app.models.school import School, SchoolState
+from app.models.student import Student
+from app.models.user import User
+from app.schemas.kpis import (
+    EngagementSummary,
+    KpiOverview,
+    KpiTrends,
+    SchoolFunnel,
+    TrendPoint,
+    UserCounts,
+)
+
+logger = get_logger()
+
+router = APIRouter(
+    tags=["KPIs"],
+    dependencies=[Depends(get_current_active_superuser_or_backend_service_account)],
+)
+
+
+def _enum_value(member) -> str:
+    return member.value if hasattr(member, "value") else str(member)
+
+
+@router.get("/kpis/overview", response_model=KpiOverview)
+async def get_kpi_overview(session: AsyncSession = Depends(get_async_session)):
+    """Headline KPIs: school funnel, user breakdown, and engagement totals.
+
+    Admin-only. Backed by grouped counts over indexed columns; cache on the
+    client (these change slowly).
+    """
+    # School funnel
+    school_rows = (
+        await session.execute(
+            select(School.state, func.count(School.id)).group_by(School.state)
+        )
+    ).all()
+    school_counts = {_enum_value(state): count for state, count in school_rows}
+    schools = SchoolFunnel(
+        active=school_counts.get(SchoolState.ACTIVE.value, 0),
+        pending=school_counts.get(SchoolState.PENDING.value, 0),
+        inactive=school_counts.get(SchoolState.INACTIVE.value, 0),
+        total=sum(school_counts.values()),
+    )
+
+    # Users by type
+    user_rows = (
+        await session.execute(
+            select(User.type, func.count(User.id)).group_by(User.type)
+        )
+    ).all()
+    by_type = {_enum_value(user_type): count for user_type, count in user_rows}
+    users = UserCounts(by_type=by_type, total=sum(by_type.values()))
+
+    # Engagement: conversation sessions by status
+    session_rows = (
+        await session.execute(
+            select(
+                ConversationSession.status, func.count(ConversationSession.id)
+            ).group_by(ConversationSession.status)
+        )
+    ).all()
+    session_counts = {_enum_value(status): count for status, count in session_rows}
+    completed = session_counts.get(SessionStatus.COMPLETED.value, 0)
+    abandoned = session_counts.get(SessionStatus.ABANDONED.value, 0)
+    active = session_counts.get(SessionStatus.ACTIVE.value, 0)
+    finished = completed + abandoned
+    completion_rate = round(completed / finished, 4) if finished else None
+
+    books_read = (
+        await session.execute(
+            select(func.count(CollectionItemActivity.id)).where(
+                CollectionItemActivity.status == CollectionItemReadStatus.READ
+            )
+        )
+    ).scalar_one()
+
+    engagement = EngagementSummary(
+        sessions_total=sum(session_counts.values()),
+        sessions_active=active,
+        sessions_completed=completed,
+        sessions_abandoned=abandoned,
+        completion_rate=completion_rate,
+        books_read=books_read,
+    )
+
+    return KpiOverview(schools=schools, users=users, engagement=engagement)
+
+
+async def _weekly_counts(
+    session: AsyncSession, timestamp_column, cutoff: datetime, *extra_filters
+) -> dict:
+    """Return {week_start_date: count} bucketed by ISO week (Postgres date_trunc)."""
+    week = func.date_trunc("week", timestamp_column).label("week")
+    query = select(week, func.count()).where(timestamp_column >= cutoff).group_by(week)
+    for clause in extra_filters:
+        query = query.where(clause)
+    rows = (await session.execute(query)).all()
+    return {row[0].date(): row[1] for row in rows}
+
+
+@router.get("/kpis/trends", response_model=KpiTrends)
+async def get_kpi_trends(
+    weeks: int = Query(12, ge=1, le=52),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Weekly trend buckets (zero-filled) for the last `weeks` ISO weeks.
+
+    Tracks new schools, new students, new educators, conversation sessions
+    started, and books marked read.
+    """
+    today = datetime.utcnow().date()
+    # Monday of the current ISO week, then walk back to the first bucket.
+    current_monday = today - timedelta(days=today.weekday())
+    first_monday = current_monday - timedelta(weeks=weeks - 1)
+    cutoff = datetime.combine(first_monday, datetime.min.time())
+
+    schools = await _weekly_counts(session, School.created_at, cutoff)
+    students = await _weekly_counts(session, Student.created_at, cutoff)
+    educators = await _weekly_counts(session, Educator.created_at, cutoff)
+    sessions = await _weekly_counts(session, ConversationSession.started_at, cutoff)
+    books_read = await _weekly_counts(
+        session,
+        CollectionItemActivity.timestamp,
+        cutoff,
+        CollectionItemActivity.status == CollectionItemReadStatus.READ,
+    )
+
+    points: list[TrendPoint] = []
+    for i in range(weeks):
+        wk = first_monday + timedelta(weeks=i)
+        points.append(
+            TrendPoint(
+                week=wk,
+                new_schools=schools.get(wk, 0),
+                new_students=students.get(wk, 0),
+                new_educators=educators.get(wk, 0),
+                conversation_sessions=sessions.get(wk, 0),
+                books_read=books_read.get(wk, 0),
+            )
+        )
+
+    return KpiTrends(weeks=weeks, points=points)

--- a/app/schemas/kpis.py
+++ b/app/schemas/kpis.py
@@ -1,0 +1,47 @@
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class SchoolFunnel(BaseModel):
+    active: int
+    pending: int
+    inactive: int
+    total: int
+
+
+class UserCounts(BaseModel):
+    """Counts keyed by UserAccountType value (student, educator, parent, ...)."""
+
+    by_type: dict[str, int]
+    total: int
+
+
+class EngagementSummary(BaseModel):
+    sessions_total: int
+    sessions_active: int
+    sessions_completed: int
+    sessions_abandoned: int
+    # completed / (completed + abandoned); null when no finished sessions yet.
+    completion_rate: float | None
+    books_read: int
+
+
+class KpiOverview(BaseModel):
+    schools: SchoolFunnel
+    users: UserCounts
+    engagement: EngagementSummary
+
+
+class TrendPoint(BaseModel):
+    week: date
+    new_schools: int
+    new_students: int
+    new_educators: int
+    conversation_sessions: int
+    books_read: int
+
+
+class KpiTrends(BaseModel):
+    weeks: int
+    points: list[TrendPoint]

--- a/app/tests/integration/test_kpis.py
+++ b/app/tests/integration/test_kpis.py
@@ -1,0 +1,105 @@
+"""Integration tests for the KPIs endpoints (/v1/kpis/*).
+
+Admin-only headline metrics and weekly trends. These assert structural
+invariants (totals equal the sum of their parts, trend buckets are
+consecutive zero-filled ISO weeks) rather than coupling to seed-data counts,
+so they stay stable as the shared test DB changes.
+"""
+
+from datetime import date, datetime, timedelta
+
+import pytest
+from starlette import status
+
+
+def _monday_of(d: date) -> date:
+    return d - timedelta(days=d.weekday())
+
+
+@pytest.mark.asyncio
+async def test_overview_requires_admin(async_client):
+    """Unauthenticated callers must not reach the KPI overview."""
+    response = await async_client.get("/v1/kpis/overview")
+    assert response.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    )
+
+
+@pytest.mark.asyncio
+async def test_overview_structure_and_consistency(
+    async_client_authenticated_as_wriveted_user,
+):
+    response = await async_client_authenticated_as_wriveted_user.get(
+        "/v1/kpis/overview"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+
+    schools = body["schools"]
+    assert schools["total"] == (
+        schools["active"] + schools["pending"] + schools["inactive"]
+    )
+    assert all(schools[k] >= 0 for k in ("active", "pending", "inactive", "total"))
+
+    users = body["users"]
+    assert users["total"] == sum(users["by_type"].values())
+
+    eng = body["engagement"]
+    assert eng["sessions_total"] >= (
+        eng["sessions_active"] + eng["sessions_completed"] + eng["sessions_abandoned"]
+    )
+    assert eng["books_read"] >= 0
+    if eng["completion_rate"] is not None:
+        assert 0.0 <= eng["completion_rate"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_trends_buckets_are_consecutive_zero_filled_weeks(
+    async_client_authenticated_as_wriveted_user,
+):
+    weeks = 6
+    response = await async_client_authenticated_as_wriveted_user.get(
+        f"/v1/kpis/trends?weeks={weeks}"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["weeks"] == weeks
+
+    points = body["points"]
+    assert len(points) == weeks
+
+    week_dates = [date.fromisoformat(p["week"]) for p in points]
+    # Every bucket is a Monday and they are consecutive, ascending.
+    assert all(d.weekday() == 0 for d in week_dates)
+    for earlier, later in zip(week_dates, week_dates[1:]):
+        assert later - earlier == timedelta(weeks=1)
+
+    # Final bucket is the current ISO week's Monday (UTC, tolerating a local
+    # vs UTC date boundary on the test host).
+    assert week_dates[-1] in {
+        _monday_of(date.today()),
+        _monday_of(datetime.utcnow().date()),
+    }
+
+    # Counts are present and non-negative.
+    for p in points:
+        for metric in (
+            "new_schools",
+            "new_students",
+            "new_educators",
+            "conversation_sessions",
+            "books_read",
+        ):
+            assert p[metric] >= 0
+
+
+@pytest.mark.asyncio
+async def test_trends_weeks_param_validated(
+    async_client_authenticated_as_wriveted_user,
+):
+    """weeks must be within [1, 52]."""
+    too_many = await async_client_authenticated_as_wriveted_user.get(
+        "/v1/kpis/trends?weeks=999"
+    )
+    assert too_many.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
## Summary

The KPIs tab embedded Metabase, whose Cloud Run service was stopped to save cost (and `METABASE_SECRET_KEY` is unset). This adds lightweight, admin-only KPI endpoints served by the **existing API** — no separate BI infra to pay for. The admin UI rework to consume these lands in a follow-up PR (wriveted-admin-ui).

## Endpoints (admin-only: Wriveted staff / backend service account)

- `GET /v1/kpis/overview`
  - **School funnel**: active / pending / inactive / total
  - **Users**: counts by `UserAccountType` + total
  - **Engagement**: conversation-session counts by status, completion rate (completed / finished), books read
- `GET /v1/kpis/trends?weeks=N` (N in 1..52, default 12)
  - Zero-filled weekly ISO buckets: new schools, new students, new educators, conversation sessions started, books read

## Notes

- All queries are `await session.execute(...)` over grouped counts on indexed columns — no event-loop blocking (cf. the #668 incident).
- Chosen metrics: school funnel, engagement, users (revenue/Stripe deferred per product call).

## Tests

`test_kpis.py` (4 integration tests): admin-only enforcement, total==sum consistency for schools/users, weekly-bucket date math (consecutive Monday-aligned zero-filled weeks), and `weeks` validation.