### PR TITLE
Per-school/per-region chatflow campaigns

### DIFF
--- a/alembic/versions/c1a2m3p4a5n6_add_campaigns.py
+++ b/alembic/versions/c1a2m3p4a5n6_add_campaigns.py
@@ -1,0 +1,133 @@
+"""Add campaigns table (per-school/per-region chatflow segments)
+
+Targeting rule + payload bundle (flow / theme / booklist) resolved per
+school / region / season. See docs/design-chatflow-segments.md.
+
+Revision ID: c1a2m3p4a5n6
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-27 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "c1a2m3p4a5n6"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # create_table auto-creates this enum type from the column definition below.
+    bias_mode = sa.Enum("boost", "filter", name="enum_campaign_bias_mode")
+
+    # Reuse the existing visibility enum type shared by CMS content/flows.
+    visibility = postgresql.ENUM(
+        "private",
+        "school",
+        "public",
+        "wriveted",
+        name="enum_cms_content_visibility",
+        create_type=False,
+    )
+
+    op.create_table(
+        "campaigns",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("slug", sa.String(length=200), nullable=True),
+        sa.Column("flow_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("theme_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("booklist_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("bias_mode", bias_mode, server_default="boost", nullable=False),
+        sa.Column("country_codes", postgresql.ARRAY(sa.String()), nullable=True),
+        sa.Column("region_states", postgresql.ARRAY(sa.String()), nullable=True),
+        sa.Column("school_ids", postgresql.ARRAY(sa.Integer()), nullable=True),
+        sa.Column("min_age", sa.Integer(), nullable=True),
+        sa.Column("max_age", sa.Integer(), nullable=True),
+        sa.Column("targeting_cel", sa.Text(), nullable=True),
+        sa.Column("active_from", sa.DateTime(), nullable=True),
+        sa.Column("active_until", sa.DateTime(), nullable=True),
+        sa.Column("priority", sa.Integer(), server_default="0", nullable=False),
+        sa.Column(
+            "is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False
+        ),
+        sa.Column("info", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("school_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "visibility",
+            visibility,
+            server_default=sa.text("'wriveted'"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("published_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["flow_id"],
+            ["flow_definitions.id"],
+            name="fk_campaign_flow",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["theme_id"],
+            ["chat_themes.id"],
+            name="fk_campaign_theme",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["booklist_id"],
+            ["book_lists.id"],
+            name="fk_campaign_booklist",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by"],
+            ["users.id"],
+            name="fk_campaign_created_by",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["school_id"],
+            ["schools.id"],
+            name="fk_campaign_school",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_campaigns_id", "campaigns", ["id"])
+    op.create_index("ix_campaigns_name", "campaigns", ["name"])
+    op.create_index("ix_campaigns_slug", "campaigns", ["slug"], unique=True)
+    op.create_index("ix_campaigns_visibility", "campaigns", ["visibility"])
+    op.create_index("ix_campaigns_is_active", "campaigns", ["is_active"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_campaigns_is_active", table_name="campaigns")
+    op.drop_index("ix_campaigns_visibility", table_name="campaigns")
+    op.drop_index("ix_campaigns_slug", table_name="campaigns")
+    op.drop_index("ix_campaigns_name", table_name="campaigns")
+    op.drop_index("ix_campaigns_id", table_name="campaigns")
+    op.drop_table("campaigns")
+    # Drop only the enum we created; enum_cms_content_visibility is shared.
+    sa.Enum(name="enum_campaign_bias_mode").drop(op.get_bind(), checkfirst=True)

--- a/alembic/versions/c1a2m3p4a5n6_add_campaigns.py
+++ b/alembic/versions/c1a2m3p4a5n6_add_campaigns.py
@@ -115,7 +115,6 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("ix_campaigns_id", "campaigns", ["id"])
     op.create_index("ix_campaigns_name", "campaigns", ["name"])
     op.create_index("ix_campaigns_slug", "campaigns", ["slug"], unique=True)
     op.create_index("ix_campaigns_visibility", "campaigns", ["visibility"])
@@ -127,7 +126,6 @@ def downgrade() -> None:
     op.drop_index("ix_campaigns_visibility", table_name="campaigns")
     op.drop_index("ix_campaigns_slug", table_name="campaigns")
     op.drop_index("ix_campaigns_name", table_name="campaigns")
-    op.drop_index("ix_campaigns_id", table_name="campaigns")
     op.drop_table("campaigns")
     # Drop only the enum we created; enum_cms_content_visibility is shared.
     sa.Enum(name="enum_campaign_bias_mode").drop(op.get_bind(), checkfirst=True)

--- a/app/api/campaigns.py
+++ b/app/api/campaigns.py
@@ -1,0 +1,98 @@
+from typing import Optional, Union
+from uuid import UUID
+
+from fastapi import APIRouter, Query, Security
+from sqlalchemy import select
+from starlette import status
+from starlette.exceptions import HTTPException
+from structlog import get_logger
+
+from app.api.dependencies.async_db_dep import DBSessionDep
+from app.api.dependencies.security import (
+    get_current_active_superuser_or_backend_service_account,
+)
+from app.models import ServiceAccount, User
+from app.models.campaign import Campaign
+from app.schemas.campaign import (
+    CampaignBrief,
+    CampaignCreateIn,
+    CampaignDetail,
+    CampaignUpdateIn,
+)
+
+logger = get_logger()
+
+router = APIRouter(
+    tags=["Campaigns"],
+    dependencies=[Security(get_current_active_superuser_or_backend_service_account)],
+)
+
+
+async def _get_or_404(session: DBSessionDep, campaign_id: UUID) -> Campaign:
+    campaign = await session.get(Campaign, campaign_id)
+    if campaign is None:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    return campaign
+
+
+@router.get("/campaigns", response_model=list[CampaignBrief])
+async def list_campaigns(
+    session: DBSessionDep,
+    is_active: Optional[bool] = Query(None),
+    school_id: Optional[int] = Query(None),
+):
+    query = select(Campaign).order_by(
+        Campaign.priority.desc(), Campaign.created_at.desc()
+    )
+    if is_active is not None:
+        query = query.where(Campaign.is_active.is_(is_active))
+    if school_id is not None:
+        query = query.where(Campaign.school_id == school_id)
+    rows = (await session.execute(query)).scalars().all()
+    return [CampaignBrief.model_validate(c) for c in rows]
+
+
+@router.post(
+    "/campaigns", response_model=CampaignDetail, status_code=status.HTTP_201_CREATED
+)
+async def create_campaign(
+    data: CampaignCreateIn,
+    session: DBSessionDep,
+    actor: Union[User, ServiceAccount] = Security(
+        get_current_active_superuser_or_backend_service_account
+    ),
+):
+    campaign = Campaign(**data.model_dump())
+    if isinstance(actor, User):
+        campaign.created_by = actor.id
+    session.add(campaign)
+    await session.commit()
+    await session.refresh(campaign)
+    logger.info("Created campaign", campaign_id=str(campaign.id), name=campaign.name)
+    return CampaignDetail.model_validate(campaign)
+
+
+@router.get("/campaigns/{campaign_id}", response_model=CampaignDetail)
+async def get_campaign(campaign_id: UUID, session: DBSessionDep):
+    return CampaignDetail.model_validate(await _get_or_404(session, campaign_id))
+
+
+@router.patch("/campaigns/{campaign_id}", response_model=CampaignDetail)
+async def update_campaign(
+    campaign_id: UUID, data: CampaignUpdateIn, session: DBSessionDep
+):
+    campaign = await _get_or_404(session, campaign_id)
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(campaign, field, value)
+    await session.commit()
+    await session.refresh(campaign)
+    logger.info("Updated campaign", campaign_id=str(campaign.id))
+    return CampaignDetail.model_validate(campaign)
+
+
+@router.delete("/campaigns/{campaign_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_campaign(campaign_id: UUID, session: DBSessionDep):
+    campaign = await _get_or_404(session, campaign_id)
+    await session.delete(campaign)
+    await session.commit()
+    logger.info("Deleted campaign", campaign_id=str(campaign_id))

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -1,4 +1,5 @@
 import secrets
+from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
@@ -29,7 +30,9 @@ from app.api.dependencies.security import (
 from app.config import get_settings
 from app.crud.cms import CRUDConversationSession
 from app.models import User
+from app.models.campaign import Campaign
 from app.models.cms import ChatTheme, SessionStatus
+from app.models.school import School
 from app.repositories.chat_repository import chat_repo
 from app.schemas.cms import (
     ConversationHistoryResponse,
@@ -42,6 +45,7 @@ from app.schemas.cms import (
 )
 from app.schemas.pagination import Pagination
 from app.security.csrf import generate_csrf_token, set_secure_session_cookie
+from app.services.campaigns import CampaignContext, resolve_campaign
 from app.services.chat_runtime import FlowNotFoundError, chat_runtime
 
 logger = get_logger()
@@ -49,6 +53,54 @@ logger = get_logger()
 router = APIRouter(
     tags=["Chat Runtime"],
 )
+
+
+async def _resolve_school_for_context(
+    session: DBSessionDep,
+    current_user: Optional[User],
+    initial_state: Optional[dict],
+) -> Optional[School]:
+    """Find the reader's school for campaign targeting.
+
+    Prefers the authenticated user's school (Students/Educators carry school_id);
+    otherwise falls back to a school_wriveted_id supplied in the session context.
+    """
+    school_id = getattr(current_user, "school_id", None) if current_user else None
+    if school_id is not None:
+        return await session.get(School, school_id)
+
+    ctx = (initial_state or {}).get("context", {}) or {}
+    swid = ctx.get("school_wriveted_id")
+    if swid:
+        result = await session.execute(
+            select(School).where(School.wriveted_identifier == swid)
+        )
+        return result.scalar_one_or_none()
+    return None
+
+
+async def _resolve_campaign_for_start(
+    session: DBSessionDep,
+    current_user: Optional[User],
+    initial_state: Optional[dict],
+) -> Optional[Campaign]:
+    """Best-effort campaign resolution for a starting session. Never raises."""
+    try:
+        school = await _resolve_school_for_context(session, current_user, initial_state)
+        context = CampaignContext(
+            now=datetime.utcnow(),
+            school_id=school.id if school else None,
+            country_code=school.country_code if school else None,
+            region_state=(
+                (school.info or {}).get("location", {}).get("state")
+                if school and school.info
+                else None
+            ),
+        )
+        return await resolve_campaign(session, context)
+    except Exception as exc:
+        logger.warning("Campaign resolution failed; using default flow", error=str(exc))
+        return None
 
 
 @router.post(
@@ -88,13 +140,40 @@ async def start_conversation(
                 )
             user_id_for_session = None  # Explicitly anonymous
 
+        # Resolve a campaign when no explicit flow_id was supplied — transparent
+        # per-school / per-region / seasonal flow selection. An explicit flow_id
+        # always overrides (testing / deep-links).
+        effective_flow_id = session_data.flow_id
+        resolved_campaign: Optional[Campaign] = None
+        initial_state = dict(session_data.initial_state or {})
+        if effective_flow_id is None:
+            resolved_campaign = await _resolve_campaign_for_start(
+                session, current_user, initial_state
+            )
+            if resolved_campaign and resolved_campaign.flow_id:
+                effective_flow_id = resolved_campaign.flow_id
+
+        if effective_flow_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No flow_id provided and no campaign matched this context.",
+            )
+
+        # Stash the resolved campaign so downstream nodes can apply its book bias.
+        if resolved_campaign is not None:
+            ctx_state = dict(initial_state.get("context", {}) or {})
+            ctx_state["campaign_id"] = str(resolved_campaign.id)
+            if resolved_campaign.booklist_id:
+                ctx_state["campaign_booklist_id"] = str(resolved_campaign.booklist_id)
+            initial_state["context"] = ctx_state
+
         # Create session using runtime
         conversation_session = await chat_runtime.start_session(
             session,
-            flow_id=session_data.flow_id,
+            flow_id=effective_flow_id,
             user_id=user_id_for_session,
             session_token=session_token,
-            initial_state=session_data.initial_state,
+            initial_state=initial_state,
         )
 
         # Resolve school name from school_wriveted_id if not already set
@@ -131,13 +210,13 @@ async def start_conversation(
 
         # Get initial node
         initial_node = await chat_runtime.get_initial_node(
-            session, session_data.flow_id, conversation_session
+            session, effective_flow_id, conversation_session
         )
 
         # Load theme if flow has one configured
         theme_id = None
         theme_response = None
-        flow = await crud.flow.aget(session, session_data.flow_id)
+        flow = await crud.flow.aget(session, effective_flow_id)
         if flow and flow.flow_data:
             # Theme ID can be in flow_data.theme_id or info.theme_id
             theme_id_str = flow.flow_data.get("theme_id") or flow.info.get("theme_id")
@@ -167,9 +246,29 @@ async def start_conversation(
                 except (ValueError, TypeError):
                     logger.warning(
                         "Invalid theme_id in flow",
-                        flow_id=session_data.flow_id,
+                        flow_id=effective_flow_id,
                         theme_id=theme_id_str,
                     )
+
+        # A resolved campaign's theme overrides the flow's default theme.
+        if resolved_campaign is not None and resolved_campaign.theme_id:
+            campaign_theme = (
+                await session.execute(
+                    select(ChatTheme).where(
+                        ChatTheme.id == resolved_campaign.theme_id,
+                        ChatTheme.is_active.is_(True),
+                    )
+                )
+            ).scalar_one_or_none()
+            if campaign_theme:
+                theme_id = campaign_theme.id
+                theme_response = {
+                    "id": str(campaign_theme.id),
+                    "name": campaign_theme.name,
+                    "config": campaign_theme.config,
+                    "logo_url": campaign_theme.logo_url,
+                    "avatar_url": campaign_theme.avatar_url,
+                }
 
         # Set secure session cookie and CSRF token
         csrf_token = generate_csrf_token()
@@ -198,7 +297,7 @@ async def start_conversation(
         logger.info(
             "Started conversation session",
             session_id=conversation_session.id,
-            flow_id=session_data.flow_id,
+            flow_id=effective_flow_id,
             user_id=conversation_session.user_id,
             csrf_token_set=True,
         )

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -87,15 +87,16 @@ async def _resolve_campaign_for_start(
     """Best-effort campaign resolution for a starting session. Never raises."""
     try:
         school = await _resolve_school_for_context(session, current_user, initial_state)
+        region_state = None
+        if school and isinstance(school.info, dict):
+            location = school.info.get("location")
+            if isinstance(location, dict):
+                region_state = location.get("state")
         context = CampaignContext(
             now=datetime.utcnow(),
             school_id=school.id if school else None,
             country_code=school.country_code if school else None,
-            region_state=(
-                (school.info or {}).get("location", {}).get("state")
-                if school and school.info
-                else None
-            ),
+            region_state=region_state,
         )
         return await resolve_campaign(session, context)
     except Exception as exc:

--- a/app/api/external_api_router.py
+++ b/app/api/external_api_router.py
@@ -7,6 +7,7 @@ from app.api.booklists import public_router as booklist_router_public
 from app.api.booklists import router as booklist_router
 from app.api.broadcast import public_router as broadcast_router_public
 from app.api.broadcast import router as broadcast_router
+from app.api.campaigns import router as campaign_router
 from app.api.chat import router as chat_router
 from app.api.chatbot_integrations import router as chatbot_integrations_router
 from app.api.classes import router as class_group_router
@@ -41,6 +42,7 @@ api_router.include_router(user_router)
 api_router.include_router(author_router)
 api_router.include_router(booklist_router)
 api_router.include_router(booklist_router_public)
+api_router.include_router(campaign_router)
 api_router.include_router(chat_router, prefix="/chat")
 api_router.include_router(chatbot_integrations_router)
 api_router.include_router(class_group_router)

--- a/app/api/recommendations.py
+++ b/app/api/recommendations.py
@@ -69,6 +69,7 @@ async def get_recommendations_with_fallback(
     background_tasks: BackgroundTasks,
     limit=5,
     remove_duplicate_authors=True,
+    boost_work_ids=None,
 ) -> Tuple[list[HueyBook], Any]:
     """
     Return (filtered_books, query_parameters) by running a single scored query
@@ -88,6 +89,7 @@ async def get_recommendations_with_fallback(
         "age": data.age,
         "recommendable_only": data.recommendable_only,
         "exclude_isbns": data.exclude_isbns or [],
+        "boost_work_ids": boost_work_ids or [],
         "limit": limit + 5,
     }
     logger.info("About to make a recommendation", query_parameters=query_parameters)
@@ -162,6 +164,7 @@ async def get_recommended_editions_and_labelsets(
     age,
     recommendable_only,
     exclude_isbns,
+    boost_work_ids=None,
     limit=5,
 ):
     """
@@ -179,5 +182,6 @@ async def get_recommended_editions_and_labelsets(
         reading_abilities=reading_abilities,
         recommendable_only=recommendable_only,
         exclude_isbns=exclude_isbns,
+        boost_work_ids=boost_work_ids,
         limit=limit,
     )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 from .author import Author
 from .booklist import BookList
 from .booklist_work_association import BookListItem
+from .campaign import Campaign, CampaignBiasMode
 from .class_group import ClassGroup
 from .cms import (
     CMSContent,

--- a/app/models/campaign.py
+++ b/app/models/campaign.py
@@ -1,0 +1,178 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from fastapi_permissions import All, Allow, Authenticated
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+from app.models.cms import ContentVisibility
+from app.schemas import CaseInsensitiveStringEnum
+
+if TYPE_CHECKING:
+    from app.models.booklist import BookList
+    from app.models.cms import ChatTheme, FlowDefinition
+
+
+class CampaignBiasMode(CaseInsensitiveStringEnum):
+    """How a campaign's booklist influences recommendations.
+
+    - BOOST: themed books score higher but the full catalogue stays available (v1).
+    - FILTER: restrict recommendations to the booklist (reserved; not implemented in v1).
+    """
+
+    BOOST = "boost"
+    FILTER = "filter"
+
+
+class Campaign(Base):
+    """A targeting rule + payload bundle that resolves a chat experience.
+
+    Resolves the right flow / visual theme / book bias for a session based on the
+    reader's school, region and the current date. See
+    docs/design-chatflow-segments.md.
+    """
+
+    __tablename__ = "campaigns"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+        primary_key=True,
+        index=True,
+        nullable=False,
+    )
+
+    name: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    slug: Mapped[Optional[str]] = mapped_column(
+        String(200), nullable=True, index=True, unique=True
+    )
+
+    # --- Payload (all optional) ---
+    flow_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        ForeignKey("flow_definitions.id", name="fk_campaign_flow", ondelete="SET NULL"),
+        nullable=True,
+    )
+    theme_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        ForeignKey("chat_themes.id", name="fk_campaign_theme", ondelete="SET NULL"),
+        nullable=True,
+    )
+    booklist_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        ForeignKey("book_lists.id", name="fk_campaign_booklist", ondelete="SET NULL"),
+        nullable=True,
+    )
+    bias_mode: Mapped[CampaignBiasMode] = mapped_column(
+        Enum(
+            CampaignBiasMode,
+            name="enum_campaign_bias_mode",
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=False,
+        default=CampaignBiasMode.BOOST,
+        server_default=CampaignBiasMode.BOOST.value,
+    )
+
+    # --- Targeting: structured (SQL-prefilterable) ---
+    country_codes: Mapped[Optional[list[str]]] = mapped_column(
+        ARRAY(String), nullable=True
+    )
+    region_states: Mapped[Optional[list[str]]] = mapped_column(
+        ARRAY(String), nullable=True
+    )
+    school_ids: Mapped[Optional[list[int]]] = mapped_column(
+        ARRAY(Integer), nullable=True
+    )
+    min_age: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    max_age: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    # --- Targeting: optional CEL escape hatch (AND-gated after the structured prefilter) ---
+    targeting_cel: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    # --- Seasonality ---
+    active_from: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    active_until: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    # --- Precedence & lifecycle ---
+    priority: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=text("true")
+    )
+
+    info: Mapped[Optional[dict]] = mapped_column(MutableDict.as_mutable(JSONB))
+
+    # --- Ownership / access / sharing ---
+    created_by: Mapped[Optional[uuid.UUID]] = mapped_column(
+        ForeignKey("users.id", name="fk_campaign_created_by", ondelete="SET NULL"),
+        nullable=True,
+    )
+    school_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("schools.id", name="fk_campaign_school", ondelete="CASCADE"),
+        nullable=True,
+    )
+    visibility: Mapped[ContentVisibility] = mapped_column(
+        Enum(
+            ContentVisibility,
+            name="enum_cms_content_visibility",
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=False,
+        default=ContentVisibility.WRIVETED,
+        server_default=text("'wriveted'"),
+        index=True,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.current_timestamp()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.current_timestamp(),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+    published_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    flow: Mapped[Optional["FlowDefinition"]] = relationship(
+        "FlowDefinition", foreign_keys=[flow_id]
+    )
+    theme: Mapped[Optional["ChatTheme"]] = relationship(
+        "ChatTheme", foreign_keys=[theme_id]
+    )
+    booklist: Mapped[Optional["BookList"]] = relationship(
+        "BookList", foreign_keys=[booklist_id]
+    )
+
+    def __repr__(self):
+        return f"<Campaign '{self.name}' id={self.id} visibility={self.visibility}>"
+
+    def __acl__(self) -> List[tuple[Any, str, str]]:
+        """Who can do what to this Campaign (mirrors BookList's school-scoped ACL)."""
+        policies = [
+            (Allow, "role:admin", All),
+            (Allow, f"user:{self.created_by}", All),
+            (Allow, f"schooladmin:{self.school_id}", All),
+            (Allow, f"educator:{self.school_id}", All),
+        ]
+        if self.school_id is not None:
+            policies.append((Allow, f"student:{self.school_id}", "read"))
+        if self.visibility in (ContentVisibility.PUBLIC, ContentVisibility.WRIVETED):
+            policies.append((Allow, Authenticated, "read"))
+        return policies

--- a/app/models/campaign.py
+++ b/app/models/campaign.py
@@ -30,8 +30,9 @@ if TYPE_CHECKING:
 class CampaignBiasMode(CaseInsensitiveStringEnum):
     """How a campaign's booklist influences recommendations.
 
-    - BOOST: themed books score higher but the full catalogue stays available (v1).
-    - FILTER: restrict recommendations to the booklist (reserved; not implemented in v1).
+    - BOOST: themed books rank higher while the full catalogue stays available.
+    - FILTER: restrict recommendations to the booklist. Not yet honoured by the
+      recommendation query, which treats every booklist as a BOOST.
     """
 
     BOOST = "boost"
@@ -53,7 +54,6 @@ class Campaign(Base):
         default=uuid.uuid4,
         server_default=text("gen_random_uuid()"),
         primary_key=True,
-        index=True,
         nullable=False,
     )
 

--- a/app/schemas/campaign.py
+++ b/app/schemas/campaign.py
@@ -91,14 +91,3 @@ class CampaignDetail(CampaignBrief):
     created_at: datetime
     updated_at: datetime
     published_at: Optional[datetime] = None
-
-
-class ResolvedCampaign(BaseModel):
-    """What the resolver returns for a session context."""
-
-    campaign_id: uuid.UUID
-    name: str
-    flow_id: Optional[uuid.UUID] = None
-    theme_id: Optional[uuid.UUID] = None
-    booklist_id: Optional[uuid.UUID] = None
-    bias_mode: CampaignBiasMode

--- a/app/schemas/campaign.py
+++ b/app/schemas/campaign.py
@@ -1,0 +1,104 @@
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from app.models.campaign import CampaignBiasMode
+from app.models.cms import ContentVisibility
+
+
+class CampaignTargeting(BaseModel):
+    country_codes: Optional[list[str]] = None
+    region_states: Optional[list[str]] = None
+    school_ids: Optional[list[int]] = None
+    min_age: Optional[int] = None
+    max_age: Optional[int] = None
+    targeting_cel: Optional[str] = None
+
+
+class CampaignBase(CampaignTargeting):
+    name: str
+    description: Optional[str] = None
+    slug: Optional[str] = None
+    flow_id: Optional[uuid.UUID] = None
+    theme_id: Optional[uuid.UUID] = None
+    booklist_id: Optional[uuid.UUID] = None
+    bias_mode: CampaignBiasMode = CampaignBiasMode.BOOST
+    active_from: Optional[datetime] = None
+    active_until: Optional[datetime] = None
+    priority: int = 0
+    is_active: bool = True
+    visibility: ContentVisibility = ContentVisibility.WRIVETED
+    school_id: Optional[int] = None
+
+
+class CampaignCreateIn(CampaignBase):
+    pass
+
+
+class CampaignUpdateIn(BaseModel):
+    """All fields optional; only provided fields are patched."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    slug: Optional[str] = None
+    flow_id: Optional[uuid.UUID] = None
+    theme_id: Optional[uuid.UUID] = None
+    booklist_id: Optional[uuid.UUID] = None
+    bias_mode: Optional[CampaignBiasMode] = None
+    country_codes: Optional[list[str]] = None
+    region_states: Optional[list[str]] = None
+    school_ids: Optional[list[int]] = None
+    min_age: Optional[int] = None
+    max_age: Optional[int] = None
+    targeting_cel: Optional[str] = None
+    active_from: Optional[datetime] = None
+    active_until: Optional[datetime] = None
+    priority: Optional[int] = None
+    is_active: Optional[bool] = None
+    visibility: Optional[ContentVisibility] = None
+    school_id: Optional[int] = None
+
+
+class CampaignBrief(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    visibility: ContentVisibility
+    is_active: bool
+    priority: int
+    flow_id: Optional[uuid.UUID] = None
+    theme_id: Optional[uuid.UUID] = None
+    booklist_id: Optional[uuid.UUID] = None
+    active_from: Optional[datetime] = None
+    active_until: Optional[datetime] = None
+
+
+class CampaignDetail(CampaignBrief):
+    description: Optional[str] = None
+    slug: Optional[str] = None
+    bias_mode: CampaignBiasMode
+    country_codes: Optional[list[str]] = None
+    region_states: Optional[list[str]] = None
+    school_ids: Optional[list[int]] = None
+    min_age: Optional[int] = None
+    max_age: Optional[int] = None
+    targeting_cel: Optional[str] = None
+    school_id: Optional[int] = None
+    created_by: Optional[uuid.UUID] = None
+    created_at: datetime
+    updated_at: datetime
+    published_at: Optional[datetime] = None
+
+
+class ResolvedCampaign(BaseModel):
+    """What the resolver returns for a session context."""
+
+    campaign_id: uuid.UUID
+    name: str
+    flow_id: Optional[uuid.UUID] = None
+    theme_id: Optional[uuid.UUID] = None
+    booklist_id: Optional[uuid.UUID] = None
+    bias_mode: CampaignBiasMode

--- a/app/schemas/cms.py
+++ b/app/schemas/cms.py
@@ -441,7 +441,10 @@ class ConnectionResponse(PaginatedResponse):
 
 # Conversation Session Schemas
 class SessionCreate(BaseModel):
-    flow_id: UUID4
+    # Optional: when omitted, the server resolves a campaign for the session
+    # context (school/region/season) and uses its flow. An explicit flow_id
+    # always overrides.
+    flow_id: Optional[UUID4] = None
     user_id: Optional[UUID4] = None
     initial_state: Optional[Dict[str, Any]] = {}
 

--- a/app/schemas/recommendations.py
+++ b/app/schemas/recommendations.py
@@ -44,6 +44,9 @@ class HueyRecommendationFilterBase(BaseModel):
 class HueyRecommendationFilter(HueyRecommendationFilterBase):
     wriveted_identifier: Optional[uuid.UUID] = None
     dedupe_authors: bool = True
+    # When set (e.g. a flow passing {{context.campaign_booklist_id}}), the
+    # booklist's works are soft-boosted in the recommendation ranking.
+    booklist_id: Optional[uuid.UUID] = None
 
 
 class HueyRecommendationFilterUsed(HueyRecommendationFilterBase):

--- a/app/services/campaigns.py
+++ b/app/services/campaigns.py
@@ -117,6 +117,30 @@ def _passes_cel(campaign: Campaign, context: CampaignContext) -> bool:
         return False
 
 
+async def get_campaign_boost_work_ids(session: AsyncSession, booklist_id) -> list[int]:
+    """Work ids in a campaign's booklist, for the recommendation book-bias BOOST.
+
+    Returns [] when there is no booklist, so callers can pass it through
+    unconditionally.
+    """
+    if not booklist_id:
+        return []
+    from app.models.booklist_work_association import BookListItem
+
+    rows = (
+        (
+            await session.execute(
+                select(BookListItem.work_id).where(
+                    BookListItem.booklist_id == booklist_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return list(rows)
+
+
 async def resolve_campaign(
     session: AsyncSession, context: CampaignContext
 ) -> Optional[Campaign]:

--- a/app/services/campaigns.py
+++ b/app/services/campaigns.py
@@ -1,0 +1,136 @@
+"""Campaign resolution: pick the best active campaign for a session context.
+
+Two-stage, matching docs/design-chatflow-segments.md §4:
+  1. An indexable SQL prefilter (lifecycle + date window + structured targeting +
+     visibility).
+  2. An optional CEL gate (only for candidates carrying ``targeting_cel``), then
+     precedence ranking in Python.
+
+All DB access is async; CEL evaluation is pure-compute (no I/O), so it is safe to run
+in the request path.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import and_, false, func, or_, select, true
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from app.models.campaign import Campaign
+from app.models.cms import ContentVisibility
+
+logger = get_logger()
+
+
+@dataclass
+class CampaignContext:
+    """The session facts a campaign is matched against."""
+
+    now: datetime
+    school_id: Optional[int] = None
+    country_code: Optional[str] = None
+    region_state: Optional[str] = None
+    age: Optional[int] = None
+
+
+def _dimension_matches(column, value):
+    """True when the campaign places no restriction on this dimension, or the
+    context value is in the campaign's allow-list."""
+    unrestricted = or_(column.is_(None), func.cardinality(column) == 0)
+    if value is None:
+        # The campaign requires a value we don't have → only matches if unrestricted.
+        return unrestricted
+    return or_(unrestricted, column.any(value))
+
+
+def _prefilter(context: CampaignContext):
+    """Build the SQL WHERE clause for the structured prefilter + visibility."""
+    window = and_(
+        or_(Campaign.active_from.is_(None), Campaign.active_from <= context.now),
+        or_(Campaign.active_until.is_(None), Campaign.active_until >= context.now),
+    )
+
+    if context.age is not None:
+        age_match = and_(
+            or_(Campaign.min_age.is_(None), Campaign.min_age <= context.age),
+            or_(Campaign.max_age.is_(None), Campaign.max_age >= context.age),
+        )
+    else:
+        # Unknown age → ignore age constraints rather than over-filter.
+        age_match = true()
+
+    visibility_conds = [
+        Campaign.visibility.in_([ContentVisibility.WRIVETED, ContentVisibility.PUBLIC])
+    ]
+    if context.school_id is not None:
+        # School-scoped (SCHOOL/PRIVATE) campaigns only reach their own school.
+        visibility_conds.append(Campaign.school_id == context.school_id)
+    visible = or_(*visibility_conds) if visibility_conds else false()
+
+    return and_(
+        Campaign.is_active.is_(True),
+        window,
+        _dimension_matches(Campaign.country_codes, context.country_code),
+        _dimension_matches(Campaign.region_states, context.region_state),
+        _dimension_matches(Campaign.school_ids, context.school_id),
+        age_match,
+        visible,
+    )
+
+
+def _specificity(campaign: Campaign) -> int:
+    """Most-specific-wins ordering: school > region > country > global."""
+    if campaign.school_ids:
+        return 3
+    if campaign.region_states:
+        return 2
+    if campaign.country_codes:
+        return 1
+    return 0
+
+
+def _passes_cel(campaign: Campaign, context: CampaignContext) -> bool:
+    if not campaign.targeting_cel:
+        return True
+    from app.services.cel_evaluator import evaluate_cel_expression
+
+    cel_context = {
+        "school": {
+            "id": context.school_id,
+            "country": context.country_code,
+            "state": context.region_state,
+        },
+        "user": {"age": context.age},
+        "now": context.now.isoformat(),
+    }
+    try:
+        return bool(evaluate_cel_expression(campaign.targeting_cel, cel_context))
+    except Exception as exc:
+        # Fail closed: a malformed targeting expression must not surface the campaign.
+        logger.warning(
+            "Campaign targeting_cel evaluation failed; skipping campaign",
+            campaign_id=str(campaign.id),
+            error=str(exc),
+        )
+        return False
+
+
+async def resolve_campaign(
+    session: AsyncSession, context: CampaignContext
+) -> Optional[Campaign]:
+    """Return the highest-precedence active campaign for the context, or None."""
+    candidates = (
+        (await session.execute(select(Campaign).where(_prefilter(context))))
+        .scalars()
+        .all()
+    )
+    candidates = [c for c in candidates if _passes_cel(c, context)]
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda c: (_specificity(c), c.priority, c.created_at),
+        reverse=True,
+    )
+    return candidates[0]

--- a/app/services/campaigns.py
+++ b/app/services/campaigns.py
@@ -1,20 +1,21 @@
 """Campaign resolution: pick the best active campaign for a session context.
 
-Two-stage, matching docs/design-chatflow-segments.md §4:
-  1. An indexable SQL prefilter (lifecycle + date window + structured targeting +
-     visibility).
-  2. An optional CEL gate (only for candidates carrying ``targeting_cel``), then
-     precedence ranking in Python.
+Resolution is two-stage:
+  1. An indexable SQL prefilter narrows candidates by lifecycle, the active date
+     window, structured targeting (country/region/school, age), and visibility.
+  2. Candidates carrying a ``targeting_cel`` expression are then passed through a
+     CEL gate, and the survivors are ranked by precedence in Python.
 
-All DB access is async; CEL evaluation is pure-compute (no I/O), so it is safe to run
-in the request path.
+DB access is async and CEL evaluation is pure-compute (no I/O), so resolution is
+safe to run inline in the request path.
 """
 
+import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import and_, false, func, or_, select, true
+from sqlalchemy import and_, func, or_, select, true
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
@@ -61,13 +62,21 @@ def _prefilter(context: CampaignContext):
         # Unknown age → ignore age constraints rather than over-filter.
         age_match = true()
 
+    # A session may be served WRIVETED- and PUBLIC-visibility campaigns globally,
+    # and a SCHOOL-visibility campaign only for its own school. PRIVATE campaigns
+    # are drafts (visible to their creator/admins for editing only) and never
+    # auto-resolve onto a live session.
     visibility_conds = [
         Campaign.visibility.in_([ContentVisibility.WRIVETED, ContentVisibility.PUBLIC])
     ]
     if context.school_id is not None:
-        # School-scoped (SCHOOL/PRIVATE) campaigns only reach their own school.
-        visibility_conds.append(Campaign.school_id == context.school_id)
-    visible = or_(*visibility_conds) if visibility_conds else false()
+        visibility_conds.append(
+            and_(
+                Campaign.school_id == context.school_id,
+                Campaign.visibility == ContentVisibility.SCHOOL,
+            )
+        )
+    visible = or_(*visibility_conds)
 
     return and_(
         Campaign.is_active.is_(True),
@@ -117,7 +126,9 @@ def _passes_cel(campaign: Campaign, context: CampaignContext) -> bool:
         return False
 
 
-async def get_campaign_boost_work_ids(session: AsyncSession, booklist_id) -> list[int]:
+async def get_campaign_boost_work_ids(
+    session: AsyncSession, booklist_id: Optional[uuid.UUID]
+) -> list[int]:
     """Work ids in a campaign's booklist, for the recommendation book-bias BOOST.
 
     Returns [] when there is no booklist, so callers can pass it through

--- a/app/services/internal_api_handlers.py
+++ b/app/services/internal_api_handlers.py
@@ -52,6 +52,12 @@ async def handle_recommend(
         limit = max(1, min(int(query_params.get("limit", 5)), 50))
     except (ValueError, TypeError):
         limit = 5
+
+    # Campaign book bias: soft-boost works from the campaign's themed booklist.
+    from app.services.campaigns import get_campaign_boost_work_ids
+
+    boost_work_ids = await get_campaign_boost_work_ids(db, data.booklist_id)
+
     recommended_books, query_parameters = await get_recommendations_with_fallback(
         asession=db,
         account=None,
@@ -59,6 +65,7 @@ async def handle_recommend(
         data=data,
         background_tasks=None,
         limit=limit,
+        boost_work_ids=boost_work_ids,
     )
 
     return {

--- a/app/services/recommendations.py
+++ b/app/services/recommendations.py
@@ -32,6 +32,7 @@ async def get_recommended_editions_from_mv(
     reading_abilities: Optional[list[str]] = None,
     recommendable_only: Optional[bool] = True,
     exclude_isbns: Optional[list[str]] = None,
+    boost_work_ids: Optional[list[int]] = None,
     limit: int = 10,
 ) -> list[tuple[Work, Edition, LabelSet]]:
     """
@@ -39,6 +40,7 @@ async def get_recommended_editions_from_mv(
 
     Scoring weights (higher = more important):
       - school_collection_match: 4  — the work's cover edition is in the school's collection
+      - booklist_boost:          3  — the work is in a campaign's themed booklist (soft BOOST)
       - reading_ability_match:   2  — the labelset covers at least one requested reading ability
       - hue_match:               1  — the labelset covers at least one requested hue
 
@@ -108,7 +110,17 @@ async def get_recommended_editions_from_mv(
             else_=literal(0),
         )
 
-    total_score = (hue_score + ra_score + school_score).label("score")
+    # Campaign book bias: soft BOOST works that belong to the active campaign's
+    # themed booklist. They score above hue/reading-ability matches but below a
+    # school-collection match, so the catalogue stays open (no hard filter).
+    booklist_score = literal(0)
+    if boost_work_ids:
+        booklist_score = case(
+            (mv.c.work_id.in_(boost_work_ids), literal(3)),
+            else_=literal(0),
+        )
+
+    total_score = (hue_score + ra_score + school_score + booklist_score).label("score")
 
     # --- Build the scored MV query ---
     scored_q = (

--- a/app/services/recommendations.py
+++ b/app/services/recommendations.py
@@ -40,7 +40,7 @@ async def get_recommended_editions_from_mv(
 
     Scoring weights (higher = more important):
       - school_collection_match: 4  — the work's cover edition is in the school's collection
-      - booklist_boost:          3  — the work is in a campaign's themed booklist (soft BOOST)
+      - booklist_boost:          3  — the work id is in boost_work_ids (e.g. a campaign's themed booklist)
       - reading_ability_match:   2  — the labelset covers at least one requested reading ability
       - hue_match:               1  — the labelset covers at least one requested hue
 

--- a/app/tests/integration/test_campaigns.py
+++ b/app/tests/integration/test_campaigns.py
@@ -225,7 +225,7 @@ async def test_start_without_flow_or_campaign_is_400(async_client):
 async def test_campaigns_forbidden_for_non_admin(
     async_client, test_schooladmin_account_token
 ):
-    """An authenticated non-Wriveted user (school admin) is forbidden, not just 401."""
+    """An authenticated non-staff user (school admin) is forbidden, not just 401."""
     async_client.headers.update(
         {"Authorization": f"bearer {test_schooladmin_account_token}"}
     )

--- a/app/tests/integration/test_campaigns.py
+++ b/app/tests/integration/test_campaigns.py
@@ -1,0 +1,216 @@
+"""Integration tests for campaigns: admin CRUD + the resolution algorithm.
+
+Covers targeting precedence (school > region > country > global), the active
+date window, visibility scoping, and the optional CEL gate.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import text
+from starlette import status
+
+from app.models.campaign import Campaign, CampaignBiasMode
+from app.models.cms import ContentVisibility, FlowDefinition, FlowNode, NodeType
+from app.services.campaigns import CampaignContext, resolve_campaign
+
+
+@pytest.fixture(autouse=True)
+async def clean_campaigns(async_session):
+    """Isolate campaigns (and the flow/session data these tests create)."""
+    stmt = text(
+        "TRUNCATE TABLE campaigns, conversation_sessions, flow_connections, "
+        "flow_nodes, flow_definitions RESTART IDENTITY CASCADE"
+    )
+    await async_session.execute(stmt)
+    await async_session.commit()
+    yield
+    await async_session.execute(stmt)
+    await async_session.commit()
+
+
+async def _add(async_session, **kwargs) -> Campaign:
+    kwargs.setdefault("visibility", ContentVisibility.WRIVETED)
+    kwargs.setdefault("bias_mode", CampaignBiasMode.BOOST)
+    kwargs.setdefault("is_active", True)
+    campaign = Campaign(**kwargs)
+    async_session.add(campaign)
+    await async_session.commit()
+    await async_session.refresh(campaign)
+    return campaign
+
+
+def _ctx(**kwargs) -> CampaignContext:
+    kwargs.setdefault("now", datetime.utcnow())
+    return CampaignContext(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Admin CRUD
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_campaigns_require_admin(async_client):
+    resp = await async_client.get("/v1/campaigns")
+    assert resp.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_get_patch_delete(async_client_authenticated_as_wriveted_user):
+    client = async_client_authenticated_as_wriveted_user
+    create = await client.post(
+        "/v1/campaigns",
+        json={"name": "Test Campaign", "country_codes": ["NZL"], "priority": 5},
+    )
+    assert create.status_code == status.HTTP_201_CREATED, create.text
+    cid = create.json()["id"]
+
+    got = await client.get(f"/v1/campaigns/{cid}")
+    assert got.status_code == 200
+    assert got.json()["country_codes"] == ["NZL"]
+
+    patched = await client.patch(f"/v1/campaigns/{cid}", json={"priority": 9})
+    assert patched.status_code == 200
+    assert patched.json()["priority"] == 9
+
+    deleted = await client.delete(f"/v1/campaigns/{cid}")
+    assert deleted.status_code == status.HTTP_204_NO_CONTENT
+    assert (await client.get(f"/v1/campaigns/{cid}")).status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Resolution
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_specificity_school_beats_country(async_session):
+    await _add(async_session, name="NZ national", country_codes=["NZL"])
+    await _add(async_session, name="School special", school_ids=[424242])
+
+    resolved = await resolve_campaign(
+        async_session, _ctx(school_id=424242, country_code="NZL")
+    )
+    assert resolved is not None and resolved.name == "School special"
+
+    # A different school falls through to the national campaign.
+    resolved_other = await resolve_campaign(
+        async_session, _ctx(school_id=999999, country_code="NZL")
+    )
+    assert resolved_other is not None and resolved_other.name == "NZ national"
+
+
+@pytest.mark.asyncio
+async def test_priority_breaks_ties(async_session):
+    await _add(async_session, name="low", country_codes=["NZL"], priority=1)
+    await _add(async_session, name="high", country_codes=["NZL"], priority=10)
+    resolved = await resolve_campaign(async_session, _ctx(country_code="NZL"))
+    assert resolved is not None and resolved.name == "high"
+
+
+@pytest.mark.asyncio
+async def test_active_window_respected(async_session):
+    now = datetime.utcnow()
+    await _add(
+        async_session,
+        name="future",
+        country_codes=["NZL"],
+        active_from=now + timedelta(days=5),
+    )
+    resolved = await resolve_campaign(async_session, _ctx(country_code="NZL", now=now))
+    assert resolved is None
+
+    await _add(
+        async_session,
+        name="current",
+        country_codes=["NZL"],
+        active_from=now - timedelta(days=1),
+        active_until=now + timedelta(days=1),
+    )
+    resolved2 = await resolve_campaign(async_session, _ctx(country_code="NZL", now=now))
+    assert resolved2 is not None and resolved2.name == "current"
+
+
+@pytest.mark.asyncio
+async def test_visibility_school_scoped(async_session, test_school):
+    await _add(
+        async_session,
+        name="school-only",
+        visibility=ContentVisibility.SCHOOL,
+        school_id=test_school.id,
+    )
+    # Visible to its own school...
+    assert (
+        await resolve_campaign(async_session, _ctx(school_id=test_school.id))
+    ).name == "school-only"
+    # ...but not to another school.
+    assert await resolve_campaign(async_session, _ctx(school_id=999999)) is None
+
+
+@pytest.mark.asyncio
+async def test_cel_gate(async_session):
+    await _add(
+        async_session,
+        name="teens-only",
+        country_codes=["NZL"],
+        targeting_cel="user.age >= 13",
+    )
+    assert (
+        await resolve_campaign(async_session, _ctx(country_code="NZL", age=15))
+    ).name == "teens-only"
+    assert (
+        await resolve_campaign(async_session, _ctx(country_code="NZL", age=8))
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_no_match_returns_none(async_session):
+    await _add(async_session, name="aus-only", country_codes=["AUS"])
+    assert await resolve_campaign(async_session, _ctx(country_code="NZL")) is None
+
+
+# --------------------------------------------------------------------------- #
+# Resolution wired into /chat/start
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_start_without_flow_resolves_campaign(async_client, async_session):
+    """No flow_id supplied → server resolves the global campaign and runs its flow."""
+    flow = FlowDefinition(
+        name="Campaign Flow",
+        version="1",
+        flow_data={"nodes": [], "connections": []},
+        entry_node_id="welcome",
+        is_published=True,
+        is_active=True,
+    )
+    async_session.add(flow)
+    await async_session.flush()
+    async_session.add(
+        FlowNode(
+            flow_id=flow.id,
+            node_id="welcome",
+            node_type=NodeType.MESSAGE,
+            content={"text": "Kia ora!"},
+            position={"x": 0, "y": 0},
+            info={},
+        )
+    )
+    await async_session.commit()
+
+    await _add(async_session, name="global-default", flow_id=flow.id)
+    resp = await async_client.post("/v1/chat/start", json={})
+    assert resp.status_code == status.HTTP_201_CREATED, resp.text
+    assert resp.json()["flow_name"] == "Campaign Flow"
+
+
+@pytest.mark.asyncio
+async def test_start_without_flow_or_campaign_is_400(async_client):
+    """No flow_id and nothing resolves → explicit 400 (not a 500/422)."""
+    resp = await async_client.post("/v1/chat/start", json={})
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/app/tests/integration/test_campaigns.py
+++ b/app/tests/integration/test_campaigns.py
@@ -214,3 +214,69 @@ async def test_start_without_flow_or_campaign_is_400(async_client):
     """No flow_id and nothing resolves → explicit 400 (not a 500/422)."""
     resp = await async_client.post("/v1/chat/start", json={})
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# --------------------------------------------------------------------------- #
+# Access control + targeting edge cases (added after adversarial review)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_campaigns_forbidden_for_non_admin(
+    async_client, test_schooladmin_account_token
+):
+    """An authenticated non-Wriveted user (school admin) is forbidden, not just 401."""
+    async_client.headers.update(
+        {"Authorization": f"bearer {test_schooladmin_account_token}"}
+    )
+    resp = await async_client.get("/v1/campaigns")
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_private_campaign_never_resolves(async_session, test_school):
+    """PRIVATE campaigns are drafts and must not auto-resolve, even at their school."""
+    await _add(
+        async_session,
+        name="private-draft",
+        visibility=ContentVisibility.PRIVATE,
+        school_id=test_school.id,
+    )
+    assert await resolve_campaign(async_session, _ctx(school_id=test_school.id)) is None
+
+
+@pytest.mark.asyncio
+async def test_region_targeting(async_session):
+    await _add(async_session, name="auckland", region_states=["Auckland"])
+    assert (
+        await resolve_campaign(async_session, _ctx(region_state="Auckland"))
+    ).name == "auckland"
+    assert await resolve_campaign(async_session, _ctx(region_state="Wellington")) is None
+
+
+@pytest.mark.asyncio
+async def test_age_filter(async_session):
+    await _add(async_session, name="teens", country_codes=["NZL"], min_age=13, max_age=18)
+    assert (
+        await resolve_campaign(async_session, _ctx(country_code="NZL", age=15))
+    ).name == "teens"
+    assert await resolve_campaign(async_session, _ctx(country_code="NZL", age=8)) is None
+    # Unknown age ignores the structured age constraint (permissive).
+    assert (
+        await resolve_campaign(async_session, _ctx(country_code="NZL"))
+    ).name == "teens"
+
+
+@pytest.mark.asyncio
+async def test_cel_unknown_age_fails_closed(async_session):
+    await _add(
+        async_session,
+        name="cel-teens",
+        country_codes=["NZL"],
+        targeting_cel="user.age >= 13",
+    )
+    assert (
+        await resolve_campaign(async_session, _ctx(country_code="NZL", age=15))
+    ).name == "cel-teens"
+    # Unknown age → CEL cannot affirm the rule → fail closed → excluded.
+    assert await resolve_campaign(async_session, _ctx(country_code="NZL")) is None

--- a/app/tests/integration/test_chat_api_error_handling.py
+++ b/app/tests/integration/test_chat_api_error_handling.py
@@ -57,17 +57,21 @@ def test_start_conversation_invalid_user_id_format(client, test_user_account_hea
 
 
 def test_start_conversation_missing_required_fields(client, test_user_account_headers):
-    """Test starting conversation with missing required fields returns 422."""
-    # Missing required flow_id field
+    """Starting without a flow_id, when no campaign resolves, is a 400.
+
+    flow_id is optional: the server resolves a campaign for the session context
+    when it is omitted. With no resolvable campaign there is nothing to run, so
+    the request is rejected with a clear 400 rather than starting a flowless
+    session.
+    """
     response = client.post(
         "v1/chat/start",
         json={"initial_state": {"user_name": "Test User"}},
         headers=test_user_account_headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    error_detail = response.json()["detail"]
-    assert any("flow_id" in str(error).lower() for error in error_detail)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "flow" in response.json()["detail"].lower()
 
 
 def test_start_conversation_invalid_data_types(client, test_user_account_headers):

--- a/app/tests/integration/test_recommendable_editions_mv.py
+++ b/app/tests/integration/test_recommendable_editions_mv.py
@@ -457,3 +457,38 @@ async def test_orm_tuples_are_valid_hueybook_source(session, async_session):
     session.delete(edition)
     session.delete(work)
     session.commit()
+
+
+@pytest.mark.asyncio
+async def test_boost_work_ids_ranks_higher(session, async_session):
+    """A work in the campaign booklist (boost_work_ids) outranks an unboosted peer."""
+    work_boost, edition_boost, labelset_boost = _make_labeled_work(
+        session, "boost-yes", hue_ids=[1], ra_ids=[1]
+    )
+    work_plain, edition_plain, labelset_plain = _make_labeled_work(
+        session, "boost-no", hue_ids=[1], ra_ids=[1]
+    )
+    _refresh_mv(session)
+
+    results = await get_recommended_editions_from_mv(
+        async_session,
+        recommendable_only=True,
+        boost_work_ids=[work_boost.id],
+        limit=200,
+    )
+    work_ids = [w.id for w, _e, _ls in results]
+    assert work_boost.id in work_ids and work_plain.id in work_ids
+    assert work_ids.index(work_boost.id) < work_ids.index(work_plain.id), (
+        "Boosted work should rank ahead of the unboosted peer"
+    )
+
+    for obj in (
+        labelset_boost,
+        edition_boost,
+        work_boost,
+        labelset_plain,
+        edition_plain,
+        work_plain,
+    ):
+        session.delete(obj)
+    session.commit()

--- a/docs/design-chatflow-segments.md
+++ b/docs/design-chatflow-segments.md
@@ -33,7 +33,7 @@ Non-goals (v1): a full visual campaign builder for educators; a public marketpla
 | Book bias in recommendations | ❌ scoring is hue / reading-ability / school-collection only; no booklist boost | `app/services/recommendations.py` |
 | Region modelling | ⚠️ country FK only; sub-national lives in `School.info.location.state` JSONB | `school.py`, `school_repository.py` |
 | **Time-windowing** (active_from/until) | ❌ nothing is date-scoped | — |
-| CMS authoring | ⚠️ WRIVETED-staff only; admin UI gated to `wriveted` | `cms.py` routers, `authenticated-page` |
+| CMS authoring | ⚠️ staff-only (the `WRIVETED` account type); admin UI gated accordingly | `cms.py` routers, `authenticated-page` |
 | Visibility enforcement in CMS ACL | ❌ `FlowDefinition.__acl__` / `CMSContent.__acl__` ignore `visibility`/`school_id` (ChatTheme & BookList *do* enforce it) | `cms.py` |
 
 **Takeaway:** the targeting/seasonality/book-bias logic is the new part. Flows, themes,
@@ -68,7 +68,7 @@ Campaign
   is_active      bool
   # Ownership / access / sharing (designed in from day one — see §7)
   created_by     -> users.id
-  school_id      -> schools.id (int)  (owner's school; null = Wriveted-global)
+  school_id      -> schools.id (int)  (owner's school; null = platform-global)
   visibility     enum PRIVATE|SCHOOL|PUBLIC|WRIVETED   (default WRIVETED)
   created_at, updated_at, published_at
 ```
@@ -210,7 +210,7 @@ whether the cloned flow/booklist are copied or referenced). A curated/featured g
 a later nicety.
 
 **Enablement is still phased** (the *model* above is built now; the surfaces open over time):
-- **Phase A — Wriveted-authored** global/region campaigns via the admin UI
+- **Phase A — staff-authored** global/region campaigns via the admin UI
   (`visibility=WRIVETED`). Ships Matariki & World Cup.
 - **Phase B — School-scoped authoring.** Educators create `visibility=SCHOOL`,
   `school_id=theirs`. Campaign ACL already supports this; remaining work is the educator
@@ -224,7 +224,7 @@ a later nicety.
   `visibility`/`school_id` (only ChatTheme & BookList enforce it). The *campaign* ACL is
   correct from day one, but **Phase B** (school-authored flows referenced by campaigns)
   must close this on the flow/content side before opening authoring. Not a blocker for
-  Phase A (Wriveted-authored).
+  Phase A (staff-authored).
 - **School FK — resolved:** campaign uses `schools.id` (int), aligning with ACL principals
   and the reader's session context (see §3 note). No reconciliation of the CMS uuid FK
   needed for this feature.
@@ -251,13 +251,13 @@ Milestones (each a reviewable PR / small set of PRs):
   `campaigns` table via alembic; Campaign model, repository, Pydantic schemas; targeting
   + precedence (school > region > country > global) + date-window resolver
   (`resolve_campaign(context)`); wire into `/chat/start` (explicit `flow_id` still
-  overrides; otherwise resolve flow + theme). Async, no blocking calls. Wriveted-only
+  overrides; otherwise resolve flow + theme). Async, no blocking calls. Staff-only
   admin CRUD endpoints. Unit + integration tests (precedence, windowing, fallback).
 - **M2 — Book bias (BOOST).** Extend `get_recommended_editions_from_mv` with
   `boost_work_ids`/`booklist_id`; recommendation node reads the active campaign's booklist
   from session context; tests for the boosted ordering.
 - **M3 — Admin authoring UI.** Campaigns list + form in the admin UI (targeting, date
-  window, payload pickers for flow/theme/booklist), Wriveted-gated; per-campaign analytics
+  window, payload pickers for flow/theme/booklist), staff-gated; per-campaign analytics
   via existing conversation-session/event data.
 - **M4 — Seed the real campaigns.** Matariki (NZL, dated window, Māori-stories booklist,
   theme) and Football World Cup (sport booklist), authored via M3.

--- a/docs/design-chatflow-segments.md
+++ b/docs/design-chatflow-segments.md
@@ -1,0 +1,274 @@
+# Design: Per-school / per-region chatflow segments ("Campaigns")
+
+**Status:** Draft for review · **Date:** 2026-06-27 · **Author:** (design spike)
+
+## 1. Problem & goals
+
+We want chat experiences that adapt to **who** the reader is (their school / region) and
+**when** it is (season, cultural moment, current event). Concrete motivating cases:
+
+- **Matariki** (NZ, ~10 days out): NZ schools get a Matariki-themed flow, visual theme,
+  and a book bias toward Matariki / Māori stories — only during the Matariki window.
+- **Football World Cup**: a football flow/theme and a bias toward sport/football books,
+  for everyone or a chosen set of schools, for the tournament window.
+
+Goals:
+1. Surface the *right* flow + visual theme + book bias for a session based on **school,
+   region, and date** — without per-campaign client changes.
+2. Make it **seasonal** (auto-activates/expires).
+3. Lay a path so that **eventually schools author and share** their own segments.
+
+Non-goals (v1): a full visual campaign builder for educators; a public marketplace.
+
+## 2. What exists today (and the gap)
+
+| Capability | State | Reference |
+|---|---|---|
+| Flow definition w/ `school_id`, `visibility` (PRIVATE/SCHOOL/PUBLIC/WRIVETED), `info` JSONB, publish/version | ✅ stored | `app/models/cms.py` FlowDefinition |
+| **Flow selection** | ⚠️ **client passes `flow_id`** to `/chat/start`; no server targeting | `app/api/chat.py`, `chat_runtime.start_session` |
+| Visual theme, school-scoped, referenced by a flow via `info.theme_id` | ✅ works | `ChatTheme`, `chat.py` theme load |
+| Content variants w/ `conditions` + `weight` | ⚠️ schema only; `conditions` not evaluated at runtime | `CMSContentVariant` |
+| School-aware content selection inside flows | ✅ `get_random_content(school_id=…)` filters by visibility | `cms_repository.py` |
+| Booklists w/ `type` (PERSONAL/SCHOOL/**REGION**/HUEY/OTHER), `sharing` (PRIVATE/RESTRICTED/PUBLIC), `slug`, mature school ACL, public router | ✅ | `app/models/booklist.py`, `app/api/booklists.py` |
+| Book bias in recommendations | ❌ scoring is hue / reading-ability / school-collection only; no booklist boost | `app/services/recommendations.py` |
+| Region modelling | ⚠️ country FK only; sub-national lives in `School.info.location.state` JSONB | `school.py`, `school_repository.py` |
+| **Time-windowing** (active_from/until) | ❌ nothing is date-scoped | — |
+| CMS authoring | ⚠️ WRIVETED-staff only; admin UI gated to `wriveted` | `cms.py` routers, `authenticated-page` |
+| Visibility enforcement in CMS ACL | ❌ `FlowDefinition.__acl__` / `CMSContent.__acl__` ignore `visibility`/`school_id` (ChatTheme & BookList *do* enforce it) | `cms.py` |
+
+**Takeaway:** the targeting/seasonality/book-bias logic is the new part. Flows, themes,
+and booklists are reusable payloads we already have.
+
+## 3. Core proposal — a `Campaign` (a.k.a. Segment) entity + server-side resolution
+
+A **Campaign** is a *targeting rule + a bundle of payloads*. It is deliberately separate
+from the flow so the same flow can be reused, and so targeting/seasonality is editable
+without touching flow internals.
+
+```
+Campaign
+  id, name, description, slug (unique; for public discovery/clone)
+  # Payload (all optional → a campaign can be just a book bias, or just a flow swap)
+  flow_id        -> FlowDefinition   (which flow to run)
+  theme_id       -> ChatTheme        (visual skin)
+  booklist_id    -> BookList         (book bias)
+  bias_mode      enum: BOOST | FILTER (v1 = BOOST only; FILTER reserved, see §5)
+  # Targeting — structured (SQL-prefilterable, author-friendly)
+  country_codes  text[]              (e.g. {"NZL"})
+  region_states  text[]              (matches School.info.location.state; optional)
+  school_ids     int[]               (schools.id allow-list; optional — see FK note)
+  min_age, max_age                   (optional reader filter)
+  # Targeting — optional power-user escape hatch
+  targeting_cel  text                (nullable CEL expression, AND-gated after the
+                                       structured prefilter; see §4a)
+  # Seasonality
+  active_from, active_until  timestamptz (nullable = open-ended)
+  # Precedence & lifecycle
+  priority       int                 (tie-break; higher wins)
+  is_active      bool
+  # Ownership / access / sharing (designed in from day one — see §7)
+  created_by     -> users.id
+  school_id      -> schools.id (int)  (owner's school; null = Wriveted-global)
+  visibility     enum PRIVATE|SCHOOL|PUBLIC|WRIVETED   (default WRIVETED)
+  created_at, updated_at, published_at
+```
+
+**School FK note (resolved):** the campaign's `school_id` and `school_ids[]` use
+`schools.id` (**int**), matching the user/booklist/educator domain — because ACL
+principals (`educator:{school_id}`, `student:{school_id}`) and the reader's session
+school context are all built from `schools.id`. (Flow/theme/booklist references are by
+their own PKs and are unaffected by this choice. Note: CMS entities — flow/theme/content —
+instead key school on `schools.wriveted_identifier` (uuid); we deliberately do **not**
+follow that here because targeting/ACL live in the user domain.)
+
+A campaign with only `booklist_id` + `bias_mode=BOOST` + `country_codes={NZL}` +
+window is exactly "bias NZ readers toward Matariki books for 3 weeks". Add `flow_id` +
+`theme_id` and it's the full Matariki special.
+
+### Why a new entity rather than targeting fields on the flow?
+- The mental model *is* a bundle ("a Matariki special" = flow + theme + books + dates).
+- Flows stay reusable; targeting/seasonality is decoupled and independently editable.
+- Natural home for precedence, date windows, and later **school authorship + sharing**
+  (a campaign is the unit a school publishes/clones — like a booklist).
+- Avoids overloading `FlowDefinition.info` JSONB with untyped targeting logic.
+
+## 4. Server-side resolution (the key change)
+
+Introduce a resolver. `/chat/start` keeps accepting an explicit `flow_id` (override, for
+testing/deep-links); **if omitted**, the server resolves the active campaign for the
+caller's context and returns the resolved `flow_id` + `theme` + active `booklist`.
+
+```
+resolve(context = {school_id?, country_code?, region_state?, age?, now}):
+  # 1. SQL prefilter — indexable, does the heavy lifting (covers Matariki/World Cup):
+  candidates = Campaign where is_active
+      and (active_from  is null or active_from  <= now)
+      and (active_until is null or active_until >= now)
+      and (school_ids    is empty or context.school_id    = any(school_ids))
+      and (country_codes is empty or context.country_code = any(country_codes))
+      and (region_states is empty or context.region_state = any(region_states))
+      and (min_age is null or context.age >= min_age) and (max_age …)
+      and visible_to(context)               # visibility/school SQL filter, §7
+  # 2. Optional CEL gate — only for the few candidates that carry targeting_cel:
+  candidates = [c for c in candidates
+                if c.targeting_cel is null or eval_cel(c.targeting_cel, context)]
+  if none: return default global flow (today's behaviour)
+  # 3. Precedence:
+  return best(candidates)
+```
+
+**Precedence (most specific wins), then `priority`, then most-recent:**
+`school_ids` match ▶ `region_states` match ▶ `country_codes` match ▶ global (no
+targeting). A school's own Matariki campaign thus overrides the national one.
+
+Resolution is cheap (small table, indexable prefilter) and cacheable; it must be
+**async / non-blocking** (cf. the recent event-loop incident). CEL eval is pure-compute
+(no I/O), runs only on the already-small prefiltered set, and should use compiled-
+expression caching.
+
+### 4a. Filtering language: structured columns + optional CEL (hybrid)
+
+We already ship a CEL evaluator (`common-expression-language`, `app/services/cel_evaluator.py`)
+with custom functions and a `/flows/evaluate-cel` test/validation endpoint. Rather than
+pick one, use both at the right layer:
+
+- **Structured columns** (`country_codes`, `region_states`, `school_ids`, age, dates) are
+  the primary mechanism: they push targeting into an **indexable SQL WHERE clause** (you
+  resolve with one query, not by loading every campaign and evaluating CEL), and they map
+  to friendly admin pickers — essential for the eventual non-technical school authors.
+  These cover the motivating cases (NZ Matariki, World-Cup-for-selected-schools) outright.
+- **Optional `targeting_cel`** is an escape hatch for logic the columns can't express
+  (e.g. `school.num_students > 200 && context.age in 8..10`), AND-gated after the SQL
+  prefilter so it only runs on a handful of rows. Reuses the existing evaluator + the
+  authoring/validation endpoint, and keeps a consistent mental model with flow conditions.
+
+Notes / small gaps to handle in M1: CEL has no `now()`/`date()` — pass `now` and any
+needed dates into the context dict (there's already a `days_since(iso)` helper); add
+compiled-expression caching; assemble the targeting context as
+`{school: {country, state, …}, user: {age, …}, now}`. (Aside: flow *connection* routing
+today uses a JSONLogic subset, not this full evaluator — unifying them is out of scope.)
+
+## 5. Book bias in recommendations
+
+**Decision (v1): soft `BOOST` only.** Add an optional parameter to
+`get_recommended_editions_from_mv`:
+- `boost_work_ids: set[int]` (or `booklist_id`) → correlated `EXISTS` against
+  `booklist_work_association`, adding a score tier (e.g. **+3**, between reading-ability
+  and school-collection) — mirrors the existing school-collection `EXISTS` boost. Themed
+  books surface more often but the full catalogue stays open (safer when a themed list is
+  small).
+
+The flow's recommendation node passes the active campaign's booklist through. The MV
+itself needs no change (booklist membership is joined at query time).
+
+`bias_mode=FILTER` (hard themed-only shelf) is **deferred** — the column is kept on the
+schema for forward-compat, but only `BOOST` is implemented in v1.
+
+## 6. Seasonality
+
+`active_from` / `active_until` on the campaign drive auto-activation/expiry — no manual
+toggling, no stale Matariki content in August. This is the one genuinely missing
+primitive (nothing in the system is date-scoped today). Resolution filters on `now()`.
+
+## 7. Access control & sharing — designed in from day one
+
+Even though educator *authoring* ships later, the campaign's access model is correct from
+the first migration so we never retrofit (and never repeat the flow/content visibility-ACL
+gap). It composes the proven **BookList** ACL + **ChatTheme** query-filter patterns.
+
+**Two complementary layers (both required — `__acl__` alone is per-object and can't gate a
+list/resolve query):**
+
+1. **Per-object `__acl__`** (governs edit/read on a single campaign), modelled on BookList:
+   ```python
+   def __acl__(self):
+       policies = [
+           (Allow, "role:admin", All),
+           (Allow, f"user:{self.created_by}", All),       # owner
+           (Allow, f"schooladmin:{self.school_id}", All),  # school admins
+           (Allow, f"educator:{self.school_id}", All),     # school educators
+       ]
+       if self.school_id is not None:
+           policies.append((Allow, f"student:{self.school_id}", "read"))
+       if self.visibility in (PUBLIC, WRIVETED):
+           policies.append((Allow, Authenticated, "read"))
+       return policies
+   ```
+   Routes load the campaign then `Permission("update", get_campaign)` — exactly the
+   booklist pattern.
+
+2. **Query-level visibility filter** (governs list + the resolver), modelled on the working
+   ChatTheme list/get: non-admins see `WRIVETED` ∪ `PUBLIC` ∪ (`SCHOOL`/`PRIVATE` where
+   `school_id == caller's school`). The resolver's `visible_to(context)` clause (§4) is
+   exactly this filter — so a session can only ever be *targeted* by a campaign it's allowed
+   to receive (a school's PRIVATE/SCHOOL campaign never leaks to other schools).
+
+**Sharing** reuses the booklist model: `visibility=PUBLIC` + unique `slug` + a public
+read/list route; "use this campaign" = **clone** into your school (flow cloning already
+exists in `flow_service.clone_flow`; extend to clone the campaign bundle — and decide
+whether the cloned flow/booklist are copied or referenced). A curated/featured gallery is
+a later nicety.
+
+**Enablement is still phased** (the *model* above is built now; the surfaces open over time):
+- **Phase A — Wriveted-authored** global/region campaigns via the admin UI
+  (`visibility=WRIVETED`). Ships Matariki & World Cup.
+- **Phase B — School-scoped authoring.** Educators create `visibility=SCHOOL`,
+  `school_id=theirs`. Campaign ACL already supports this; remaining work is the educator
+  authoring surface **and** closing the **FlowDefinition/CMSContent** visibility-ACL gap
+  (campaigns are correct, but a school-authored *flow* they reference must also be
+  access-correct) — see §8.
+- **Phase C — Cross-school sharing** (PUBLIC + slug + clone), per above.
+
+## 8. Risks / gaps to close
+- **FlowDefinition/CMSContent visibility-ACL gap** — their `__acl__` ignores
+  `visibility`/`school_id` (only ChatTheme & BookList enforce it). The *campaign* ACL is
+  correct from day one, but **Phase B** (school-authored flows referenced by campaigns)
+  must close this on the flow/content side before opening authoring. Not a blocker for
+  Phase A (Wriveted-authored).
+- **School FK — resolved:** campaign uses `schools.id` (int), aligning with ACL principals
+  and the reader's session context (see §3 note). No reconciliation of the CMS uuid FK
+  needed for this feature.
+- **No first-class Region entity** — v1 uses `country_codes` + `region_states` (the latter
+  matched against `School.info.location.state` JSONB; ensure schools are populated, else
+  region targeting silently matches nothing). Add a Region model only if demand appears;
+  NZ-wide = `{NZL}` suffices now.
+- **CEL** — add `now`/dates to the eval context (no `now()`/`date()` builtins) and compiled-
+  expression caching; keep `targeting_cel` optional so the common path is pure SQL.
+- Resolution must stay async / off the event loop (no blocking SDK calls).
+
+## 9. Delivery plan
+
+**Decisions (owner, 2026-06-27):** build the **general framework first** (Matariki lands
+when ready, not rushed); v1 supports the **full bundle** (flow + theme + book bias); book
+bias is **soft BOOST** in v1.
+
+Resolution lives transparently inside `/chat/start`, so the consumer app needs **no
+per-campaign change** — this sidesteps the "which app renders flows" concern for v1.
+
+Milestones (each a reviewable PR / small set of PRs):
+
+- **M1 — Campaign entity + resolver (backend core).**
+  `campaigns` table via alembic; Campaign model, repository, Pydantic schemas; targeting
+  + precedence (school > region > country > global) + date-window resolver
+  (`resolve_campaign(context)`); wire into `/chat/start` (explicit `flow_id` still
+  overrides; otherwise resolve flow + theme). Async, no blocking calls. Wriveted-only
+  admin CRUD endpoints. Unit + integration tests (precedence, windowing, fallback).
+- **M2 — Book bias (BOOST).** Extend `get_recommended_editions_from_mv` with
+  `boost_work_ids`/`booklist_id`; recommendation node reads the active campaign's booklist
+  from session context; tests for the boosted ordering.
+- **M3 — Admin authoring UI.** Campaigns list + form in the admin UI (targeting, date
+  window, payload pickers for flow/theme/booklist), Wriveted-gated; per-campaign analytics
+  via existing conversation-session/event data.
+- **M4 — Seed the real campaigns.** Matariki (NZL, dated window, Māori-stories booklist,
+  theme) and Football World Cup (sport booklist), authored via M3.
+
+**Later (Phase B/C):** school-authored campaigns (`visibility=SCHOOL`) — *prerequisite:*
+close the CMS visibility-ACL gap (§8); then clone-and-share public campaigns.
+
+## 10. Resolved decisions
+- ✅ Sequencing = framework-first · ✅ v1 = full bundle · ✅ bias = soft BOOST.
+- ✅ Filtering = hybrid: structured columns (primary, SQL-prefilter) + optional `targeting_cel`.
+- ✅ Access control & sharing designed in from the first migration (owner / school-scoped /
+  public-shareable), via `__acl__` + query-level visibility filter.
+- ✅ School FK = `schools.id` (int).
+- ✅ Consumer-surface concern resolved by making resolution transparent in `/chat/start`.


### PR DESCRIPTION
## Overview

Implements **Campaigns** — a targeting rule + payload bundle (flow + theme + booklist) that resolves the right chat experience per **school / region / season**. Motivating cases: a Matariki special for NZ schools, a Football World Cup theme + book bias.

Full design in `docs/design-chatflow-segments.md` (this PR's first commit).

### Key decisions
- **Server-side resolution** wired into `/chat/start` (explicit `flow_id` still overrides; otherwise resolve by school/region/now → flow + theme + booklist). Consumer app needs no per-campaign change.
- **Hybrid targeting**: structured columns (`country_codes`, `region_states`, `school_ids`, age, date window) as an indexable SQL prefilter + optional `targeting_cel` escape hatch (reuses existing CEL evaluator).
- **Book bias**: soft `BOOST` (themed books score higher; catalogue stays open).
- **Seasonality**: `active_from` / `active_until`.
- **Access control & sharing** designed in from the first migration: owner / school-scoped / public-shareable, via `__acl__` + query-level visibility filter (BookList + ChatTheme patterns). School FK = `schools.id` (int).

## Milestones (built incrementally on this branch)
- [ ] **M1** — Campaign entity + migration + resolver wired into `/chat/start` + staff-only admin CRUD + tests
- [ ] **M2** — Book-bias BOOST in the recommendation query
- [ ] **M3** — Admin authoring UI (campaigns list + form)
- [ ] **M4** — Seed Matariki + World Cup campaigns

Draft until the milestones land and are validated.
