### PR TITLE
Fix broadcast emails never being delivered

### DIFF
--- a/.cloudbuild/cloudbuild-main-branch.yaml
+++ b/.cloudbuild/cloudbuild-main-branch.yaml
@@ -46,6 +46,7 @@ steps:
         ENABLE_OTEL_GOOGLE_EXPORTER=True,
         NIELSEN_API_URL=https://ws.nielsenbookdataonline.com/BDOLRest/RESTwebServices/BDOLrequest,
         NIELSEN_CLIENT_ID=WrivetedWebServices,
+        WRIVETED_API_BASE_URL=https://wriveted-api-development-main-branch-lg5ntws4da-ts.a.run.app,
         OTEL_SERVICE_NAME=nonprod-api
       - >-
         --set-secrets=
@@ -89,6 +90,7 @@ steps:
         NIELSEN_API_URL=https://ws.nielsenbookdataonline.com/BDOLRest/RESTwebServices/BDOLrequest,
         NIELSEN_CLIENT_ID=WrivetedWebServices,
         ENABLE_OTEL_GOOGLE_EXPORTER=True,
+        WRIVETED_API_BASE_URL=https://wriveted-api-development-main-branch-lg5ntws4da-ts.a.run.app,
         OTEL_SERVICE_NAME=nonprod-api-internal
       - >-
         --set-secrets=
@@ -132,6 +134,7 @@ steps:
         NIELSEN_API_URL=https://ws.nielsenbookdataonline.com/BDOLRest/RESTwebServices/BDOLrequest,
         NIELSEN_CLIENT_ID=WrivetedWebServices,
         ENABLE_OTEL_GOOGLE_EXPORTER=True,
+        WRIVETED_API_BASE_URL=https://api.wriveted.com,
         OTEL_SERVICE_NAME=wriveted-api
       - >-
         --set-secrets=
@@ -174,6 +177,7 @@ steps:
         NIELSEN_API_URL=https://ws.nielsenbookdataonline.com/BDOLRest/RESTwebServices/BDOLrequest,
         NIELSEN_CLIENT_ID=WrivetedWebServices,
         ENABLE_OTEL_GOOGLE_EXPORTER=True,
+        WRIVETED_API_BASE_URL=https://api.wriveted.com,
         OTEL_SERVICE_NAME=wriveted-api-internal
       - >-
         --set-secrets=

--- a/app/api/internal/__init__.py
+++ b/app/api/internal/__init__.py
@@ -81,14 +81,25 @@ async def process_outbox_events(session: DBSessionDep):
 
     This is the new unified background processor that handles all reliable
     event delivery including Slack alerts, webhooks, and internal processing.
+
+    Drains in batches until no more events are ready, bounded so one
+    invocation can't run unattended forever. Failed events get a future
+    next_retry_at, so they aren't re-picked within an invocation.
     """
     from app.services.event_outbox_service import EventOutboxService
 
     outbox_service = EventOutboxService()
-    stats = await outbox_service.process_pending_events(session)
+    max_batches = 20
+    totals: dict[str, int] = {}
+    for _ in range(max_batches):
+        stats = await outbox_service.process_pending_events(session)
+        for key, value in stats.items():
+            totals[key] = totals.get(key, 0) + value
+        if stats.get("processed", 0) < outbox_service.batch_size:
+            break
 
-    logger.info("EventOutbox processing completed", stats=stats)
-    return {"msg": "EventOutbox processing completed", "stats": stats}
+    logger.info("EventOutbox processing completed", stats=totals)
+    return {"msg": "EventOutbox processing completed", "stats": totals}
 
 
 class EventSlackAlertPayload(BaseModel):

--- a/app/services/broadcast.py
+++ b/app/services/broadcast.py
@@ -23,6 +23,7 @@ from app.models.student import Student
 from app.models.user import User
 from app.schemas.broadcast import BroadcastAudience
 from app.schemas.sendgrid import SendGridEmailData
+from app.services.background_tasks import queue_background_task
 from app.services.email_notification import EmailType, create_email_notification_service
 
 logger = get_logger()
@@ -174,6 +175,21 @@ def _queue_email(
     )
 
 
+def _trigger_outbox_processing() -> None:
+    """Ask the internal API to deliver queued outbox events now.
+
+    Best-effort: the periodic outbox sweep will still deliver anything queued
+    if this nudge fails, so a Cloud Tasks hiccup must not fail the request.
+    """
+    try:
+        queue_background_task("process-outbox-events")
+    except Exception as e:
+        logger.warning(
+            "Failed to trigger outbox processing; the scheduled sweep will deliver",
+            error=str(e),
+        )
+
+
 def send_broadcast(
     db: Session,
     *,
@@ -218,6 +234,10 @@ def send_broadcast(
             },
             account=account,
         )
+        # The request session never commits on its own; without this the
+        # queued outbox rows are rolled back when the session closes.
+        db.commit()
+        _trigger_outbox_processing()
 
     return len(recipients)
 
@@ -234,6 +254,10 @@ def send_test(db: Session, *, subject: str, body: str, account) -> int:
         html=html,
         user_id=account.id,
     )
+    # The request session never commits on its own; without this the
+    # queued outbox row is rolled back when the session closes.
+    db.commit()
+    _trigger_outbox_processing()
     logger.info("Broadcast test queued", to=account.email, subject=subject)
     return 1
 

--- a/app/tests/integration/test_broadcast.py
+++ b/app/tests/integration/test_broadcast.py
@@ -7,7 +7,10 @@ round-trips and flips the opt-out flag.
 
 import uuid
 
+from sqlalchemy import select
+
 from app.models.educator import Educator
+from app.models.event_outbox import EventOutbox
 from app.models.user import UserAccountType
 from app.schemas.broadcast import BroadcastAudience
 from app.services import broadcast as bc
@@ -151,7 +154,11 @@ def test_preview_requires_admin(client):
 def test_send_requires_admin(client):
     resp = client.post(
         "/v1/broadcast",
-        json={"subject": "Hi", "body": "Hello", "audience": {"user_types": ["educator"]}},
+        json={
+            "subject": "Hi",
+            "body": "Hello",
+            "audience": {"user_types": ["educator"]},
+        },
     )
     assert resp.status_code in (401, 403)
 
@@ -181,14 +188,63 @@ def test_preview_counts_recipients(
     assert resp.json()["recipient_count"] >= 1
 
 
-def test_test_send_goes_to_self_only(client, test_wrivetedadmin_account_headers):
+def _committed_email_events(session, subject: str) -> list[EventOutbox]:
+    """Outbox email rows for the given subject, as visible to a clean transaction.
+
+    Rolling back first discards anything pending on this session, so a
+    non-empty result proves the rows were actually committed.
+    """
+    session.rollback()
+    rows = session.scalars(
+        select(EventOutbox).where(EventOutbox.event_type == "email_notification")
+    ).all()
+    return [r for r in rows if r.payload["email_data"]["subject"] == subject]
+
+
+def test_test_send_goes_to_self_only(
+    client, test_wrivetedadmin_account_headers, session, monkeypatch
+):
+    triggered = []
+    monkeypatch.setattr(
+        bc,
+        "queue_background_task",
+        lambda endpoint, payload=None: triggered.append(endpoint),
+    )
+    subject = f"Test send {uuid.uuid4().hex[:8]}"
     resp = client.post(
         "/v1/broadcast/test",
         headers=test_wrivetedadmin_account_headers,
-        json={"subject": "Hi", "body": "Hello there"},
+        json={"subject": subject, "body": "Hello there"},
     )
     assert resp.status_code == 200
     assert resp.json()["queued"] == 1
+
+    events = _committed_email_events(session, f"[Test] {subject}")
+    assert len(events) == 1
+    assert triggered == ["process-outbox-events"]
+
+
+def test_send_broadcast_commits_outbox_rows(session, test_school, monkeypatch):
+    educator = _make_educator(session, test_school.id)
+    monkeypatch.setattr(
+        bc, "queue_background_task", lambda endpoint, payload=None: None
+    )
+
+    subject = f"Broadcast {uuid.uuid4().hex[:8]}"
+    queued = bc.send_broadcast(
+        session,
+        subject=subject,
+        body="Hello everyone",
+        audience=BroadcastAudience(
+            user_types=[UserAccountType.EDUCATOR],
+            school_id=test_school.wriveted_identifier,
+        ),
+    )
+    assert queued >= 1
+
+    events = _committed_email_events(session, subject)
+    assert len(events) == queued
+    assert any(e.payload["email_data"]["to_emails"] == [educator.email] for e in events)
 
 
 def test_unsubscribe_get_does_not_mutate(client, session, test_school):


### PR DESCRIPTION
## Problem

Broadcast **test sends and real sends queued outbox rows but never committed them**, so no email was ever delivered. Verified against production: a test send logged \`Broadcast test queued\` → \`Event added to outbox (sync)\` → HTTP 200, but zero rows landed in \`event_outbox\`.

Root cause: the sync session (\`get_session\`, \`autocommit=False\`) is never committed on teardown, and \`publish_event_sync\` deliberately does \`db.add(event)\` without committing ("let the calling transaction manage it"). \`send_broadcast\` only survived by accident — a trailing \`crud.event.create(commit=True)\` audit call flushed the session. \`send_test\` had no such call, so it silently dropped every row.

Separately: **nothing runs the outbox processor in prod** (5,571 events sat PENDING since February; now retired to DEAD_LETTER). A Cloud Scheduler sweep is being added in the IaC repo.

## Changes

- **Commit explicitly** after queuing in \`send_test\` and \`send_broadcast\`, then nudge delivery via the internal \`process-outbox-events\` Cloud Task (best-effort; the scheduled sweep is the backstop).
- **Drain the outbox in batches** in \`/process-outbox-events\` (was capped at one batch of 100 — the February backlog would have starved a LOW-priority marketing email).
- **Set \`WRIVETED_API_BASE_URL\` per environment** in the deploy config, so unsubscribe links point at the right API. Previously unset → dev/preview test emails linked to the *production* API.
- **Test now asserts committed rows** (rolls back the test session, queries \`event_outbox\`) instead of trusting the Python-computed \`queued\` count — the assertion that let this ship broken.

## Testing

\`bash scripts/integration-tests.sh -k broadcast\` → 16 passed. Ruff clean.

## Note

The same missing-commit pattern affects 3 other outbox callers (commerce \`/sendgrid/email\`, internal \`/event-to-slack-alert\`, and the Stripe subscription welcome email). Those are tracked for a focused follow-up PR.