### PR TITLE
Add blockbuster to detect event-loop blocking in tests

### DIFF
--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -23,6 +23,28 @@ from starlette.testclient import TestClient
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(autouse=True)
+def detect_blocking_calls():
+    """Fail tests that make blocking calls on the asyncio event loop.
+
+    The API serves concurrency=20 per Cloud Run instance, so one synchronous
+    blocking call (a sync SDK, file, or socket op inside an async handler)
+    stalls every other coroutine on that instance. blockbuster monkeypatches
+    known-blocking stdlib calls to raise when invoked inside the running loop.
+
+    Off by default because it surfaces pre-existing blocking calls that must be
+    offloaded first; enable with BLOCKBUSTER=1 to hunt them down.
+    """
+    if not os.environ.get("BLOCKBUSTER"):
+        yield
+        return
+
+    from blockbuster import blockbuster_ctx
+
+    with blockbuster_ctx():
+        yield
+
+
 # Global engine cache to prevent creating too many engines
 # Note: Only cache sync engines due to asyncio event loop conflicts with async engines
 _test_engine_cache = {}

--- a/app/tests/integration/test_blockbuster_validation.py
+++ b/app/tests/integration/test_blockbuster_validation.py
@@ -1,0 +1,51 @@
+"""Proves the BLOCKBUSTER autouse fixture actually detects event-loop blocking.
+
+These tests only mean anything with BLOCKBUSTER=1 (which activates the autouse
+`detect_blocking_calls` fixture); they are skipped otherwise so the default
+suite is unaffected. They deliberately make a Python-level blocking call
+(`time.sleep`) on the running loop and assert blockbuster raises.
+
+Note: blockbuster instruments Python-level blocking (sleep, file I/O, the
+stdlib socket used by sync HTTP SDKs like SendGrid/Stripe). It cannot see
+blocking I/O inside C extensions such as psycopg2, so sync DB calls are not
+detected by this tool.
+"""
+
+import os
+import time
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from blockbuster import BlockingError
+
+blockbuster_only = pytest.mark.skipif(
+    not os.environ.get("BLOCKBUSTER"),
+    reason="requires BLOCKBUSTER=1 to activate the detect_blocking_calls fixture",
+)
+
+
+@blockbuster_only
+@pytest.mark.asyncio
+async def test_detects_blocking_in_async_test():
+    """A blocking call directly on the test's running loop is caught."""
+    with pytest.raises(BlockingError):
+        time.sleep(0.01)
+
+
+_blocking_app = FastAPI()
+
+
+@_blocking_app.get("/blocking")
+async def _blocking_endpoint():
+    time.sleep(0.01)  # blocking call on the request loop
+    return {"ok": True}
+
+
+@blockbuster_only
+def test_detects_blocking_in_async_endpoint_via_testclient():
+    """A blocking call inside an async endpoint driven by TestClient is caught."""
+    client = TestClient(_blocking_app)
+    with pytest.raises(BlockingError):
+        client.get("/blocking")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dev = [
     "mypy>=1.16.0,<2",
     "types-setuptools>=80.9.0.20250529,<81",
     "psutil>=6.0,<7",
+    "blockbuster>=1.5.26",
 ]
 
 [tool.uv]

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -84,6 +84,9 @@ TEST_DB_ENV=(
   -e SQLALCHEMY_ASYNC_URI=postgresql+asyncpg://postgres:password@db/postgres
   -e POSTGRESQL_USER=postgres
   -e POSTGRESQL_PASSWORD=password
+  # Forward the host value (if set) so `BLOCKBUSTER=1 bash scripts/integration-tests.sh`
+  # actually activates blockbuster inside the test container.
+  -e "BLOCKBUSTER=${BLOCKBUSTER:-}"
 )
 
 # Now start the integration tests

--- a/uv.lock
+++ b/uv.lock
@@ -273,6 +273,18 @@ wheels = [
 ]
 
 [[package]]
+name = "blockbuster"
+version = "1.5.26"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "forbiddenfruit", marker = "implementation_name == 'cpython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e0/dcbab602790a576b0b94108c07e2c048e5897df7cc83722a89582d733987/blockbuster-1.5.26.tar.gz", hash = "sha256:cc3ce8c70fa852a97ee3411155f31e4ad2665cd1c6c7d2f8bb1851dab61dc629", size = 36085, upload-time = "2025-12-05T10:43:47.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/c1/84fc6811122f54b20de2e5afb312ee07a3a47a328755587d1e505475239b/blockbuster-1.5.26-py3-none-any.whl", hash = "sha256:f8e53fb2dd4b6c6ec2f04907ddbd063ca7cd1ef587d24448ef4e50e81e3a79bb", size = 13226, upload-time = "2025-12-05T10:43:48.778Z" },
+]
+
+[[package]]
 name = "brotli"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -804,6 +816,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/fd/a5/15fe839297d761e04
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/26/d4d1629f846ae2913e88f74955a3c3f41f3863e74c5fbc1cb79af9550717/flupy-1.2.3-py3-none-any.whl", hash = "sha256:be0f5a393bad2b3534697fbab17081993cd3f5817169dd3a61e8b2e0887612e6", size = 12512, upload-time = "2025-07-18T20:15:21.384Z" },
 ]
+
+[[package]]
+name = "forbiddenfruit"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/79/d4f20e91327c98096d605646bdc6a5ffedae820f38d378d3515c42ec5e60/forbiddenfruit-0.1.4.tar.gz", hash = "sha256:e3f7e66561a29ae129aac139a85d610dbf3dd896128187ed5454b6421f624253", size = 43756, upload-time = "2021-01-16T21:03:35.401Z" }
 
 [[package]]
 name = "frozenlist"
@@ -3517,6 +3535,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "blockbuster" },
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
@@ -3587,6 +3606,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "blockbuster", specifier = ">=1.5.26" },
     { name = "google-api-python-client", specifier = ">=2.191,<3" },
     { name = "google-auth-httplib2", specifier = ">=0.2,<0.3" },
     { name = "google-auth-oauthlib", specifier = ">=1.0,<2" },


### PR DESCRIPTION
## Why

The API serves `concurrency=20` per Cloud Run instance, so a single synchronous blocking call inside an async handler (a sync SDK over the stdlib socket, file I/O, `time.sleep`) stalls **every** coroutine on that instance. [blockbuster](https://github.com/cbornet/blockbuster) monkeypatches known-blocking calls to raise `BlockingError` when invoked on the running loop, turning "silent stall" into "loud test failure".

## Changes

- Added `blockbuster` as a dev dependency.
- Autouse integration fixture that activates it per test, **off by default** (enabling repo-wide today would fail tests that legitimately block; it surfaces work to do). Enable with `BLOCKBUSTER=1`.
- **Forward `BLOCKBUSTER` into the test container.** The harness runs pytest inside docker via `docker compose run`, which doesn't inherit the host env — so `BLOCKBUSTER=1 bash scripts/integration-tests.sh` previously had *no effect* (the flag never reached pytest). Fixed by forwarding it with `-e`.
- **`test_blockbuster_validation.py`** proving detection actually works: a blocking `time.sleep` is caught both in an async test and inside an async endpoint driven by `TestClient` (2 passing tests under `BLOCKBUSTER=1`).

## Scope / limitations

- Catches **Python-level** blocking (sleep, file I/O, the stdlib socket used by sync HTTP SDKs like SendGrid/Stripe/Slack/OpenAI).
- Does **not** see blocking inside C extensions (e.g. `psycopg2`), so sync DB calls aren't detected by this tool.
- Sync `def` endpoints run in a threadpool (off the loop) and are correctly not flagged.

## Follow-up

Run `BLOCKBUSTER=1 bash scripts/integration-tests.sh` against the full suite to triage real offenders (likely sync HTTP SDK calls from async paths), fix them (offload to threadpool / async client / outbox), then flip the fixture on by default.