### PR TITLE
Fix outbox emails/alerts lost by missing commits

### DIFF
--- a/app/api/commerce.py
+++ b/app/api/commerce.py
@@ -103,6 +103,9 @@ async def send_email(
         email_type=EmailType.SYSTEM,  # Commerce API emails are system-level
         service_account_id=str(account.id),
     )
+    # publish_event_sync only adds the outbox row; the request session is never
+    # committed on teardown, so commit here or the queued email is discarded.
+    session.commit()
 
     return Response(status_code=202, content="Email queued for reliable delivery.")
 

--- a/app/api/internal/__init__.py
+++ b/app/api/internal/__init__.py
@@ -116,6 +116,9 @@ def event_to_slack_alert(
     handle_event_to_slack_alert(
         session, data.event_id, data.slack_channel, extra=data.slack_extra
     )
+    # The alert is queued as an outbox row via publish_event_sync, which does not
+    # commit; the request session would otherwise roll it back on teardown.
+    session.commit()
 
 
 class StripeInternalEventPayload(BaseModel):

--- a/app/services/stripe_events.py
+++ b/app/services/stripe_events.py
@@ -415,6 +415,10 @@ def _handle_checkout_session_completed(
             email_type=EmailType.TRANSACTIONAL,
             user_id=str(wriveted_user.id) if wriveted_user else None,
         )
+        # create_event above already committed the subscription; this queues the
+        # welcome email as a separate outbox row that publish_event_sync does not
+        # commit, so persist it before the session closes.
+        session.commit()
     elif wriveted_parent_id is not None and not stripe_customer_email:
         logger.warning(
             "Skipping subscription welcome email - no customer email address available"

--- a/app/tests/integration/test_commerce_api.py
+++ b/app/tests/integration/test_commerce_api.py
@@ -1,4 +1,32 @@
+from sqlalchemy import text
 from starlette import status
+
+
+def test_sendgrid_email_endpoint_commits_outbox_row(
+    client, backend_service_account, backend_service_account_headers, session
+):
+    """The /sendgrid/email endpoint must commit the queued outbox row.
+
+    publish_event_sync only adds the row; if the endpoint doesn't commit, the
+    request session rolls it back on teardown and the email is silently lost.
+    """
+
+    def email_count() -> int:
+        session.rollback()  # see only committed state
+        return session.execute(
+            text(
+                "SELECT COUNT(*) FROM event_outbox WHERE event_type='email_notification'"
+            )
+        ).scalar()
+
+    before = email_count()
+    resp = client.post(
+        "/v1/sendgrid/email",
+        headers=backend_service_account_headers,
+        json={"to_emails": ["someone@example.com"], "subject": "Hi there"},
+    )
+    assert resp.status_code == 202
+    assert email_count() == before + 1
 
 
 def test_stripe_webhook_requires_stripe_sig_header(

--- a/app/tests/integration/test_slack_notification_integration.py
+++ b/app/tests/integration/test_slack_notification_integration.py
@@ -537,3 +537,42 @@ class TestSlackNotificationIntegration:
 
         for expected in expected_destinations:
             assert expected in actual_destinations
+
+
+def test_event_to_slack_alert_endpoint_commits_outbox_row(session):
+    """The deprecated /event-to-slack-alert endpoint must commit its outbox row.
+
+    handle_event_to_slack_alert queues the alert via publish_event_sync, which
+    does not commit; the endpoint owns the request transaction and must persist
+    it, or the alert is discarded when the session closes.
+    """
+    from starlette.testclient import TestClient
+
+    from app.internal_api import internal_app
+
+    event = crud.event.create(
+        session,
+        title="Outbox commit regression",
+        level=EventLevel.ERROR,
+        commit=True,
+    )
+
+    def slack_count() -> int:
+        session.rollback()  # observe only committed state
+        return session.execute(
+            text(
+                "SELECT COUNT(*) FROM event_outbox WHERE event_type='slack_notification'"
+            )
+        ).scalar()
+
+    before = slack_count()
+    with TestClient(internal_app) as internal_client:
+        resp = internal_client.post(
+            "/v1/event-to-slack-alert",
+            json={
+                "event_id": str(event.id),
+                "slack_channel": EventSlackChannel.GENERAL.value,
+            },
+        )
+    assert resp.status_code == 200
+    assert slack_count() == before + 1

--- a/app/tests/integration/test_stripe_welcome_email_migration.py
+++ b/app/tests/integration/test_stripe_welcome_email_migration.py
@@ -77,7 +77,10 @@ def test_stripe_welcome_email_creates_outbox_event(session):
             session, parent_user, None, checkout_session_data
         )
 
-        session.commit()
+        # Roll back rather than commit: the outbox row must have been committed by
+        # the handler itself. A manual commit here would mask a missing commit in
+        # the production path (which is exactly how that bug shipped before).
+        session.rollback()
 
         # Verify an outbox event was created
         result = session.execute(text("SELECT COUNT(*) FROM event_outbox"))
@@ -210,9 +213,9 @@ def test_stripe_welcome_email_not_sent_for_non_parent(session):
         )
         final_email_count = result.scalar()
 
-        assert (
-            final_email_count == initial_email_count
-        ), "Welcome email was sent for non-parent user"
+        assert final_email_count == initial_email_count, (
+            "Welcome email was sent for non-parent user"
+        )
 
 
 # @pytest.mark.asyncio  # Not needed for sync tests
@@ -287,6 +290,6 @@ def test_stripe_welcome_email_not_sent_without_customer_email(session):
         )
         final_email_count = result.scalar()
 
-        assert (
-            final_email_count == initial_email_count
-        ), "Welcome email was sent without customer email"
+        assert final_email_count == initial_email_count, (
+            "Welcome email was sent without customer email"
+        )


### PR DESCRIPTION
## Problem

Follow-up to #674. The same missing-commit bug affected three more outbox callers. Each queues a row via `publish_event_sync` — which does `db.add(event)` and deliberately does **not** commit (the caller owns the transaction) — on the request-scoped sync session, which `get_session` never commits on teardown. Result: HTTP success, row rolled back, nothing delivered.

| Site | Impact |
|---|---|
| commerce `POST /sendgrid/email` | System/API emails never sent |
| internal `POST /event-to-slack-alert` (legacy) | Slack alerts on this deprecated path never delivered |
| Stripe subscription welcome email | **Paying customers created correctly but never emailed their membership welcome** |

The Stripe one is the most valuable: `create_event` commits the subscription, so the account is right and support tickets wouldn't reveal the miss — only the welcome email silently vanishes.

## Fix

An explicit `session.commit()` after each enqueue.

## Tests

Each test now asserts the row **survives a `session.rollback()`** — i.e. production committed it — rather than doing a manual commit in the test (which is exactly how the existing Stripe test passed while prod dropped the email). The masking manual commit in `test_stripe_welcome_email_creates_outbox_event` is replaced with a rollback.

`integration-tests.sh -k "sendgrid_email_endpoint or event_to_slack_alert_endpoint or stripe_welcome_email or handle_event_to_slack_alert"` → 6 passed. Ruff clean.

## Note

The audit also flagged some async paths (`action_processor`, `flow_service`, `cms`/`campaigns` write endpoints) that weren't fully traced. `get_async_session` has the same no-commit-on-teardown behavior, so those are worth a follow-up audit.