### PR TITLE
Clear easy deprecation warnings

### DIFF
--- a/app/api/booklists.py
+++ b/app/api/booklists.py
@@ -114,7 +114,7 @@ def add_booklist(
             else:
                 logger.debug("Couldn't identify one school from given information")
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail="Need to know which school to use",
                 )
         if not has_permission(principals, "update", school_orm):
@@ -138,7 +138,7 @@ def add_booklist(
                 booklist.user_id = account.id
             else:
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail="Only user accounts may create book lists without specifying the user",
                 )
 
@@ -166,7 +166,7 @@ def add_booklist(
     except IntegrityError as e:
         logger.warning("Database integrity error while adding booklist", exc_info=e)
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Couldn't create booklist",
         )
 

--- a/app/api/editions.py
+++ b/app/api/editions.py
@@ -91,7 +91,7 @@ def get_book_by_isbn(isbn: str, session: Session = Depends(get_session)):
     try:
         isbn = get_definitive_isbn(isbn)
     except AssertionError:
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "Invalid isbn")
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "Invalid isbn")
 
     return edition_repository.get_or_404(db=session, isbn=isbn)
 
@@ -104,7 +104,7 @@ def add_edition(
     try:
         edition = edition_repository.create_new_edition(session, edition_data)
     except ValueError as e:
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, str(e))
 
     if edition:
         return edition

--- a/app/api/onboarding.py
+++ b/app/api/onboarding.py
@@ -111,7 +111,7 @@ async def onboard_school(
     else:
         if not request.school_name or not request.country_code:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail="school_name and country_code are required when creating a new school",
             )
         try:

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -134,7 +134,7 @@ async def update_user(
         update_data = InternalUserUpdateIn(current_type=user.type, **updated_items)
     except ValidationError as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=json.loads(e.json()),
         )
     except ValueError as e:

--- a/app/main.py
+++ b/app/main.py
@@ -110,7 +110,7 @@ if settings.BACKEND_CORS_ORIGINS:
         CORSMiddleware,
         allow_origins=[str(origin) for origin in settings.BACKEND_CORS_ORIGINS],
         # allow preview channels from library dashboard app frontend
-        allow_origin_regex="(https:\/\/wriveted.*web\.app)|(https:\/\/huey-books.*web\.app)",
+        allow_origin_regex=r"(https://wriveted.*web\.app)|(https://huey-books.*web\.app)",
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/app/services/collections.py
+++ b/app/services/collections.py
@@ -161,7 +161,7 @@ async def add_editions_to_collection_by_isbn(
 
     if not final_primary_keys:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="No valid ISBNs were found in input",
         )
 
@@ -200,7 +200,7 @@ async def add_editions_to_collection_by_isbn(
             "IntegrityError when adding editions to collection", exc_info=True
         )
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Couldn't process input",
         )
 

--- a/app/tests/integration/test_api.py
+++ b/app/tests/integration/test_api.py
@@ -65,7 +65,7 @@ def test_school_exists_bad_uuid(client, backend_service_account_headers):
     response = client.get(
         "v1/school/not-a-uuid/exists", headers=backend_service_account_headers
     )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_school_exists_missing_uuid(client, backend_service_account_headers):

--- a/app/tests/integration/test_api_cms_content.py
+++ b/app/tests/integration/test_api_cms_content.py
@@ -408,7 +408,7 @@ class TestContentValidation:
             headers=backend_service_account_headers,
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     async def test_missing_required_fields(
         self, async_client, backend_service_account_headers
@@ -427,7 +427,7 @@ class TestContentValidation:
             headers=backend_service_account_headers,
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     async def test_get_nonexistent_content(
         self, async_client, backend_service_account_headers

--- a/app/tests/integration/test_api_cms_flows.py
+++ b/app/tests/integration/test_api_cms_flows.py
@@ -647,7 +647,7 @@ class TestFlowValidation:
             headers=backend_service_account_headers,
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     async def test_get_nonexistent_flow(
         self, async_client, backend_service_account_headers

--- a/app/tests/integration/test_booklist_api.py
+++ b/app/tests/integration/test_booklist_api.py
@@ -21,7 +21,7 @@ def test_create_empty_booklist_invalid_data_returns_validation_error(
         headers=backend_service_account_headers,
         json={"name": "my almost valid booklist", "type": "an invalid book list type"},
     )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_create_empty_booklist(client, test_user_account_headers):

--- a/app/tests/integration/test_chat_api.py
+++ b/app/tests/integration/test_chat_api.py
@@ -657,7 +657,7 @@ def test_malformed_interaction_data(client, test_flow_with_nodes):
         headers=headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_invalid_state_update_data(client, test_flow_with_nodes):
@@ -684,7 +684,7 @@ def test_invalid_state_update_data(client, test_flow_with_nodes):
         f"v1/chat/sessions/{session_token}/state", json=invalid_update, headers=headers
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 # Input Validation Tests

--- a/app/tests/integration/test_chat_api_error_handling.py
+++ b/app/tests/integration/test_chat_api_error_handling.py
@@ -24,7 +24,7 @@ def test_start_conversation_invalid_flow_id_format(client, test_user_account_hea
         headers=test_user_account_headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     error_detail = response.json()["detail"]
     # Should mention UUID validation error
     assert any(
@@ -48,7 +48,7 @@ def test_start_conversation_invalid_user_id_format(client, test_user_account_hea
         headers=test_user_account_headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     error_detail = response.json()["detail"]
     assert any(
         "uuid" in str(error).lower() or "invalid" in str(error).lower()
@@ -85,7 +85,7 @@ def test_start_conversation_invalid_data_types(client, test_user_account_headers
         headers=test_user_account_headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_interact_invalid_session_token_format(client):
@@ -131,7 +131,7 @@ def test_interact_invalid_input_type(client, test_user_account_headers):
     )
 
     # Should get validation error for invalid input_type
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     error_detail = response.json()["detail"]
     # Should mention invalid input_type
     assert any("input_type" in str(error).lower() for error in error_detail)
@@ -165,7 +165,7 @@ def test_interact_empty_input(client, test_user_account_headers):
     # Empty input might be valid in some contexts, so accept both outcomes
     assert response.status_code in [
         status.HTTP_200_OK,
-        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status.HTTP_422_UNPROCESSABLE_CONTENT,
     ]
 
 
@@ -188,7 +188,7 @@ def test_interact_missing_required_fields(client):
     )
 
     # Should get validation error for missing input_type
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     error_detail = response.json()["detail"]
     assert any("input_type" in str(error).lower() for error in error_detail)
 
@@ -212,7 +212,7 @@ def test_update_session_state_invalid_revision_format(client):
     )
 
     # Should get validation error for invalid revision format
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     error_detail = response.json()["detail"]
     # Should mention expected_revision validation error
     assert any("expected_revision" in str(error).lower() for error in error_detail)
@@ -254,8 +254,8 @@ def test_start_conversation_oversized_initial_state(client, test_user_account_he
     # Should either succeed (if no size limits) or fail gracefully
     assert response.status_code in [
         status.HTTP_201_CREATED,
-        status.HTTP_422_UNPROCESSABLE_ENTITY,
-        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+        status.HTTP_422_UNPROCESSABLE_CONTENT,
+        status.HTTP_413_CONTENT_TOO_LARGE,
         status.HTTP_404_NOT_FOUND,  # Flow doesn't exist
     ]
 
@@ -290,8 +290,8 @@ def test_interact_oversized_input(client, test_user_account_headers):
     # Should handle gracefully
     assert response.status_code in [
         status.HTTP_200_OK,
-        status.HTTP_422_UNPROCESSABLE_ENTITY,
-        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+        status.HTTP_422_UNPROCESSABLE_CONTENT,
+        status.HTTP_413_CONTENT_TOO_LARGE,
     ]
 
 
@@ -673,7 +673,7 @@ def test_session_token_boundary_cases(client):
         # Should return proper error codes, not server errors
         assert response.status_code in [
             status.HTTP_404_NOT_FOUND,
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
             status.HTTP_400_BAD_REQUEST,
         ]
 
@@ -700,7 +700,7 @@ def test_malformed_json_requests(client, test_user_account_headers):
 
             # Should return validation error, not server error
             assert response.status_code in [
-                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status.HTTP_422_UNPROCESSABLE_CONTENT,
                 status.HTTP_400_BAD_REQUEST,
             ]
         except Exception:
@@ -723,6 +723,6 @@ def test_session_operations_with_null_values(client, test_user_account_headers):
     # Should handle null values gracefully
     assert response.status_code in [
         status.HTTP_201_CREATED,
-        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status.HTTP_422_UNPROCESSABLE_CONTENT,
         status.HTTP_404_NOT_FOUND,
     ]

--- a/app/tests/integration/test_cms.py
+++ b/app/tests/integration/test_cms.py
@@ -1016,7 +1016,7 @@ def test_invalid_content_type(client, backend_service_account_headers):
         "v1/cms/content", json=invalid_content, headers=backend_service_account_headers
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_validate_flow(client, backend_service_account_headers):

--- a/app/tests/integration/test_cms_authentication.py
+++ b/app/tests/integration/test_cms_authentication.py
@@ -165,7 +165,7 @@ class TestCMSAuthentication:
         assert response.status_code != status.HTTP_401_UNAUTHORIZED
         assert response.status_code in [
             status.HTTP_404_NOT_FOUND,
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
         ]
 
 
@@ -427,7 +427,7 @@ class TestSecurityBoundaries:
         # Should return 200 (query handled safely) or 422 (validation error)
         assert response.status_code in [
             status.HTTP_200_OK,
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
         ]
 
         # Database should still be intact - try normal query
@@ -488,4 +488,4 @@ class TestSecurityBoundaries:
             assert "alert(" not in data["content"]["text"]
         else:
             # Or the request should be rejected for validation reasons
-            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+            assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/app/tests/integration/test_cms_content.py
+++ b/app/tests/integration/test_cms_content.py
@@ -672,7 +672,7 @@ class TestContentValidation:
             "v1/cms/content", json=content_data, headers=backend_service_account_headers
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_create_content_missing_content(
         self, client, backend_service_account_headers
@@ -687,7 +687,7 @@ class TestContentValidation:
             "v1/cms/content", json=content_data, headers=backend_service_account_headers
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_create_content_empty_content(
         self, client, backend_service_account_headers
@@ -702,7 +702,7 @@ class TestContentValidation:
             "v1/cms/content", json=content_data, headers=backend_service_account_headers
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_update_content_invalid_status(
         self, client, backend_service_account_headers
@@ -723,7 +723,7 @@ class TestContentValidation:
             headers=backend_service_account_headers,
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 class TestContentBulkOperations:

--- a/app/tests/integration/test_cms_error_handling.py
+++ b/app/tests/integration/test_cms_error_handling.py
@@ -250,7 +250,7 @@ def test_create_content_missing_required_fields(
         headers=backend_service_account_headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     error_detail = response.json()["detail"]
     # Should mention the missing field
     assert any("type" in str(error).lower() for error in error_detail)
@@ -267,7 +267,7 @@ def test_create_content_invalid_content_type(client, backend_service_account_hea
         "v1/cms/content", json=invalid_content, headers=backend_service_account_headers
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_create_content_invalid_data_types(client, backend_service_account_headers):
@@ -282,7 +282,7 @@ def test_create_content_invalid_data_types(client, backend_service_account_heade
         "v1/cms/content", json=invalid_content, headers=backend_service_account_headers
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_create_flow_missing_required_fields(client, backend_service_account_headers):
@@ -297,7 +297,7 @@ def test_create_flow_missing_required_fields(client, backend_service_account_hea
         "v1/cms/flows", json=malformed_flow, headers=backend_service_account_headers
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     error_detail = response.json()["detail"]
     # Should mention the missing field
     assert any("name" in str(error).lower() for error in error_detail)
@@ -334,7 +334,7 @@ def test_create_flow_node_missing_required_content_fields(
         headers=backend_service_account_headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     error_detail = response.json()["detail"]
     assert any("content" in str(error).lower() for error in error_detail)
 
@@ -367,7 +367,7 @@ def test_create_flow_node_invalid_node_type(client, backend_service_account_head
         headers=backend_service_account_headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_update_content_invalid_uuid(client, backend_service_account_headers):
@@ -381,7 +381,7 @@ def test_update_content_invalid_uuid(client, backend_service_account_headers):
         headers=backend_service_account_headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_create_content_variant_missing_fields(client, backend_service_account_headers):
@@ -409,7 +409,7 @@ def test_create_content_variant_missing_fields(client, backend_service_account_h
         headers=backend_service_account_headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     error_detail = response.json()["detail"]
     assert any("variant_key" in str(error).lower() for error in error_detail)
 
@@ -442,7 +442,7 @@ def test_create_flow_connection_missing_fields(client, backend_service_account_h
         headers=backend_service_account_headers,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     error_detail = response.json()["detail"]
     assert any("target_node_id" in str(error).lower() for error in error_detail)
 
@@ -728,7 +728,7 @@ def test_create_content_with_extremely_long_tags(
     # We're testing that the API handles it gracefully either way
     assert response.status_code in [
         status.HTTP_201_CREATED,
-        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status.HTTP_422_UNPROCESSABLE_CONTENT,
     ]
 
 
@@ -755,7 +755,7 @@ def test_create_flow_with_circular_reference_data(
     # Should either succeed or fail gracefully with validation error
     assert response.status_code in [
         status.HTTP_201_CREATED,
-        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status.HTTP_422_UNPROCESSABLE_CONTENT,
     ]
 
     # If it succeeded, the nested data should be preserved

--- a/app/tests/integration/test_cms_integration_workflows.py
+++ b/app/tests/integration/test_cms_integration_workflows.py
@@ -592,7 +592,7 @@ class TestErrorRecoveryWorkflows:
         response = await async_client.post(
             "/v1/cms/flows", json=invalid_flow, headers=backend_service_account_headers
         )
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
         # Correct the errors and retry
         valid_flow = {

--- a/app/tests/integration/test_cms_themes_api.py
+++ b/app/tests/integration/test_cms_themes_api.py
@@ -465,7 +465,7 @@ class TestThemeValidation:
 
         assert response.status_code in [
             status.HTTP_400_BAD_REQUEST,
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
         ]
 
     def test_create_theme_missing_required_fields(
@@ -482,7 +482,7 @@ class TestThemeValidation:
             headers=test_wrivetedadmin_account_headers,
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_update_theme_partial_config(
         self, client, test_wrivetedadmin_account_headers

--- a/app/tests/integration/test_commerce_api.py
+++ b/app/tests/integration/test_commerce_api.py
@@ -45,7 +45,7 @@ def test_stripe_webhook_requires_stripe_sig_header(
         headers={},
     )
 
-    assert webhook_response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert webhook_response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_stripe_webhook_validates_signature(

--- a/app/tests/integration/test_kpis.py
+++ b/app/tests/integration/test_kpis.py
@@ -102,4 +102,4 @@ async def test_trends_weeks_param_validated(
     too_many = await async_client_authenticated_as_wriveted_user.get(
         "/v1/kpis/trends?weeks=999"
     )
-    assert too_many.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert too_many.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/app/tests/integration/test_onboarding.py
+++ b/app/tests/integration/test_onboarding.py
@@ -103,7 +103,10 @@ def test_onboard_existing_school(
         name=f"Existing School {secrets.token_hex(4)}",
         country_code="ATA",
         state=SchoolState.INACTIVE,
-        info={"location": {"state": "Test", "postcode": "1234"}, "experiments": get_experiments({})},
+        info={
+            "location": {"state": "Test", "postcode": "1234"},
+            "experiments": get_experiments({}),
+        },
     )
     session.add(school)
     session.commit()
@@ -137,7 +140,10 @@ def test_onboard_active_school_rejected(
         name=f"Active School {secrets.token_hex(4)}",
         country_code="ATA",
         state=SchoolState.ACTIVE,
-        info={"location": {"state": "Test", "postcode": "1234"}, "experiments": get_experiments({})},
+        info={
+            "location": {"state": "Test", "postcode": "1234"},
+            "experiments": get_experiments({}),
+        },
     )
     session.add(school)
     session.commit()
@@ -209,9 +215,9 @@ def test_onboard_creates_event(
     assert response.status_code == 200
 
     # Check an event was created
-    events = session.query(Event).filter(
-        Event.title == "School onboarding request"
-    ).all()
+    events = (
+        session.query(Event).filter(Event.title == "School onboarding request").all()
+    )
     matching = [e for e in events if school_name in (e.description or "")]
     assert len(matching) >= 1
     assert matching[0].info["contact_name"] == "Event Tester"
@@ -245,6 +251,6 @@ def test_onboard_promotes_user_to_school_admin(
     with session_factory() as fresh_session:
         from app.models.user import User
 
-        user = fresh_session.query(User).get(user_id)
+        user = fresh_session.get(User, user_id)
         assert user is not None
         assert user.type == UserAccountType.SCHOOL_ADMIN

--- a/app/tests/integration/test_user_api.py
+++ b/app/tests/integration/test_user_api.py
@@ -42,7 +42,7 @@ def test_update_public_user_to_student_type(
         json=user_type_update,
     )
 
-    assert failed_update_response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert failed_update_response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # now add the class_id, completing the requirements to convert from public to student
     user_type_update["class_group_id"] = str(test_class_group.id)


### PR DESCRIPTION
Clears the low-risk deprecation warnings surfaced by the test suite.

- **CORS regex**: `allow_origin_regex` used a plain string with invalid `\/` escapes (`DeprecationWarning: invalid escape sequence`). Now a raw string; the compiled pattern is identical.
- **Starlette status constants**: `HTTP_422_UNPROCESSABLE_ENTITY` → `HTTP_422_UNPROCESSABLE_CONTENT`, `HTTP_413_REQUEST_ENTITY_TOO_LARGE` → `HTTP_413_CONTENT_TOO_LARGE` across app + tests (same integer values; old names deprecated). 20 files.
- **SQLAlchemy**: `Session.get(User, id)` instead of legacy `Query.get()` in `test_onboarding`.

Left alone (not "easy" / behavioural): the `httpx`+`TestClient` deprecation (needs httpx2), the `TestClient(timeout=...)` deprecation, and the DELETE-rowcount `SAWarning`s (needs `confirm_deleted_rows=False` mapper config).

`integration-tests.sh -k "test_onboarding or sendgrid_email_endpoint or test_kpis"` → 15 passed. Ruff clean.