### PR TITLE
Link family-signup chatflow readers to the authenticated user

### DIFF
--- a/app/api/onboarding.py
+++ b/app/api/onboarding.py
@@ -32,11 +32,6 @@ _PROMOTABLE_TO_SCHOOL_ADMIN = {
     UserAccountType.STUDENT,
     UserAccountType.SUPPORTER,
 }
-_PROMOTABLE_TO_PARENT = {
-    UserAccountType.PUBLIC,
-    UserAccountType.STUDENT,
-    UserAccountType.SUPPORTER,
-}
 
 
 class SchoolLocationInput(BaseModel):
@@ -301,68 +296,16 @@ async def onboard_family(
     Promotes the authenticated user to Parent type and creates
     child reader accounts linked to them.
     """
-    from app.models.public_reader import PublicReader
+    from app.services.onboarding_service import create_linked_family_readers
 
     user_id = current_user.id
 
-    # Promote to Parent if needed
-    if current_user.type != UserAccountType.PARENT:
-        if current_user.type not in _PROMOTABLE_TO_PARENT:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"Your account type ({current_user.type.value}) cannot be converted to a parent account. Contact support.",
-            )
-
-        safe_type_table_map = {
-            UserAccountType.PUBLIC: "public_readers",
-            UserAccountType.STUDENT: "students",
-            UserAccountType.SUPPORTER: "supporters",
-        }
-        subclass_table = safe_type_table_map.get(current_user.type)
-        if subclass_table:
-            await db.execute(
-                text(f"DELETE FROM {subclass_table} WHERE id = :uid"),
-                {"uid": user_id},
-            )
-
-        # Also remove from readers if present
-        await db.execute(
-            text("DELETE FROM readers WHERE id = :uid"),
-            {"uid": user_id},
-        )
-
-        await db.execute(
-            text("UPDATE users SET type = :new_type, name = :name WHERE id = :uid"),
-            {
-                "new_type": UserAccountType.PARENT.value.upper(),
-                "name": request.parent_name,
-                "uid": user_id,
-            },
-        )
-
-        # Insert into parents table
-        await db.execute(
-            text("INSERT INTO parents (id) VALUES (:uid) ON CONFLICT (id) DO NOTHING"),
-            {"uid": user_id},
-        )
-
-        await db.flush()
-
-    # Create child readers
-    children_created = 0
-    for child in request.children:
-        child_reader = PublicReader(
-            name=child.name,
-            first_name=child.name,
-            parent_id=user_id,
-            huey_attributes={
-                "age": child.age,
-                "reading_ability": child.reading_ability,
-                "interests": child.interests,
-            },
-        )
-        db.add(child_reader)
-        children_created += 1
+    children_created = await create_linked_family_readers(
+        db,
+        user=current_user,
+        parent_name=request.parent_name,
+        children=[c.model_dump() for c in request.children],
+    )
 
     # Create event
     await event_repository.acreate(

--- a/app/services/action_processor.py
+++ b/app/services/action_processor.py
@@ -356,7 +356,7 @@ class ActionNodeProcessor(NodeProcessor):
 
                 try:
                     result_data = await INTERNAL_HANDLERS[endpoint](
-                        db, resolved_body, resolved_params
+                        db, resolved_body, resolved_params, context
                     )
                 except Exception:
                     logger.error(

--- a/app/services/internal_api_handlers.py
+++ b/app/services/internal_api_handlers.py
@@ -5,15 +5,19 @@ avoiding authentication requirements and HTTP overhead for anonymous
 chatbot sessions.
 """
 
-from typing import Any, Callable, Coroutine, Dict
+from typing import Any, Callable, Coroutine, Dict, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
 logger = get_logger()
 
+# Handlers receive the resolved request body, query params, and the action
+# execution context (which carries ``session_user_id`` when the chat session is
+# authenticated). ``context`` is optional so handlers that don't need it can
+# ignore it.
 InternalHandler = Callable[
-    [AsyncSession, Dict[str, Any], Dict[str, Any]],
+    [AsyncSession, Dict[str, Any], Dict[str, Any], Optional[Dict[str, Any]]],
     Coroutine[Any, Any, Dict[str, Any]],
 ]
 
@@ -35,6 +39,7 @@ async def handle_recommend(
     db: AsyncSession,
     body: Dict[str, Any],
     query_params: Dict[str, Any],
+    context: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Direct service call for book recommendations."""
     from app.api.recommendations import get_recommendations_with_fallback
@@ -80,48 +85,59 @@ async def handle_family_onboarding(
     db: AsyncSession,
     body: Dict[str, Any],
     query_params: Dict[str, Any],
+    context: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """Direct service call for family onboarding from chatflow.
+    """Direct service call for family onboarding from the chatflow.
 
-    Creates child reader profiles. Since chatflow sessions are anonymous,
-    these readers are unlinked (no parent_id) until the user signs in
-    and claims them via the authenticated onboarding endpoint.
+    Creates child reader profiles linked to the authenticated chat session's
+    user. The family flow signs the user in before the chat starts, so the
+    session carries a ``session_user_id``. When the session is anonymous we
+    create nothing — profiles must belong to an account — and ask the user to
+    sign in.
     """
-    from app.models.public_reader import PublicReader
+    from uuid import UUID
 
-    children = body.get("children", [])
-    if not isinstance(children, list):
+    from app.models.user import User
+    from app.services.onboarding_service import (
+        create_linked_family_readers,
+        normalise_chatflow_child,
+    )
+
+    session_user_id = (context or {}).get("session_user_id")
+    if not session_user_id:
+        logger.warning("Family onboarding attempted without an authenticated session")
+        return {
+            "children_created": 0,
+            "message": "Please sign in to save reader profiles.",
+        }
+
+    raw_children = body.get("children", [])
+    if not isinstance(raw_children, list):
         return {"children_created": 0, "message": "Invalid children data"}
 
-    # Cap at 10 children per request
-    children = children[:10]
+    # Cap at 10 children per request, dropping malformed entries.
+    children = []
+    for child in raw_children[:10]:
+        normalised = normalise_chatflow_child(child)
+        if normalised is not None:
+            children.append(normalised)
 
-    children_created = 0
-    for child in children:
-        if not isinstance(child, dict) or not child.get("name"):
-            continue
-        name = str(child["name"])[:200]
-        age = child.get("age")
-        if isinstance(age, str):
-            try:
-                age = int(age)
-            except ValueError:
-                age = None
-        if age is not None and (age < 2 or age > 18):
-            age = None
-        reader = PublicReader(
-            name=name,
-            first_name=name,
-            huey_attributes={
-                "age": age,
-                "reading_ability": str(child.get("reading_ability", ""))[:50] or None,
-            },
+    user = await db.get(User, UUID(str(session_user_id)))
+    if user is None:
+        logger.warning(
+            "Family onboarding session user not found",
+            session_user_id=session_user_id,
         )
-        db.add(reader)
-        children_created += 1
+        return {"children_created": 0, "message": "Account not found."}
 
-    if children_created > 0:
-        await db.flush()
+    parent_name = str(body.get("parent_name") or user.name or "")[:200]
+
+    children_created = await create_linked_family_readers(
+        db,
+        user=user,
+        parent_name=parent_name,
+        children=children,
+    )
 
     return {
         "children_created": children_created,

--- a/app/services/onboarding_service.py
+++ b/app/services/onboarding_service.py
@@ -1,0 +1,156 @@
+"""Shared family-onboarding logic.
+
+Used by both the authenticated HTTP endpoint (``app.api.onboarding.onboard_family``)
+and the chatflow internal handler
+(``app.services.internal_api_handlers.handle_family_onboarding``) so that reader
+profiles are created and linked to a parent account in exactly one place.
+"""
+
+from typing import Any, Mapping, Optional, Sequence
+
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette import status
+from structlog import get_logger
+
+from app.models.user import User, UserAccountType
+
+logger = get_logger()
+
+# Account types that can be safely promoted to a Parent account.
+_PROMOTABLE_TO_PARENT = {
+    UserAccountType.PUBLIC,
+    UserAccountType.STUDENT,
+    UserAccountType.SUPPORTER,
+}
+
+# Subclass tables to clear when converting a user to another account type.
+_SUBCLASS_TABLE_BY_TYPE = {
+    UserAccountType.PUBLIC: "public_readers",
+    UserAccountType.STUDENT: "students",
+    UserAccountType.SUPPORTER: "supporters",
+}
+
+
+async def _promote_to_parent(db: AsyncSession, user: User, parent_name: str) -> None:
+    """Promote an authenticated user to a Parent account, preserving identity.
+
+    Mirrors the promotion performed for school admins: remove the user from
+    their current subclass table, flip ``users.type`` to PARENT and insert into
+    the ``parents`` table. No-op when the user is already a parent.
+    """
+    if user.type not in _PROMOTABLE_TO_PARENT:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Your account type ({user.type.value}) cannot be converted to "
+                "a parent account. Contact support."
+            ),
+        )
+
+    user_id = user.id
+
+    subclass_table = _SUBCLASS_TABLE_BY_TYPE.get(user.type)
+    if subclass_table:
+        await db.execute(
+            text(f"DELETE FROM {subclass_table} WHERE id = :uid"),
+            {"uid": user_id},
+        )
+
+    # PUBLIC/STUDENT inherit from Reader — remove that row too.
+    await db.execute(
+        text("DELETE FROM readers WHERE id = :uid"),
+        {"uid": user_id},
+    )
+
+    await db.execute(
+        text("UPDATE users SET type = :new_type, name = :name WHERE id = :uid"),
+        {
+            "new_type": UserAccountType.PARENT.value.upper(),
+            "name": parent_name,
+            "uid": user_id,
+        },
+    )
+
+    await db.execute(
+        text("INSERT INTO parents (id) VALUES (:uid) ON CONFLICT (id) DO NOTHING"),
+        {"uid": user_id},
+    )
+
+    await db.flush()
+
+
+async def create_linked_family_readers(
+    db: AsyncSession,
+    *,
+    user: User,
+    parent_name: str,
+    children: Sequence[Mapping[str, Any]],
+) -> int:
+    """Create child reader profiles linked to ``user`` as their parent.
+
+    Promotes the user to a Parent account if needed, then creates one
+    ``PublicReader`` per child with ``parent_id`` set. Flushes but does not
+    commit — the caller controls the transaction boundary.
+
+    ``children`` is a sequence of normalised mappings with keys ``name`` (str,
+    required), ``age`` (Optional[int]), ``reading_ability`` (Optional[str]) and
+    ``interests`` (Optional[list[str]]).
+
+    Returns the number of readers created.
+    """
+    from app.models.public_reader import PublicReader
+
+    if user.type != UserAccountType.PARENT:
+        await _promote_to_parent(db, user, parent_name)
+
+    children_created = 0
+    for child in children:
+        name = child.get("name")
+        if not name:
+            continue
+        reader = PublicReader(
+            name=name,
+            first_name=name,
+            parent_id=user.id,
+            huey_attributes={
+                "age": child.get("age"),
+                "reading_ability": child.get("reading_ability"),
+                "interests": child.get("interests"),
+            },
+        )
+        db.add(reader)
+        children_created += 1
+
+    if children_created > 0:
+        await db.flush()
+
+    return children_created
+
+
+def normalise_chatflow_child(child: Any) -> Optional[dict]:
+    """Normalise a raw child dict from chatflow session state.
+
+    Applies the same defensive validation the anonymous handler used: requires
+    a name (truncated to 200 chars), coerces age to int and drops it if outside
+    2–18, and truncates reading_ability. Returns ``None`` for entries that
+    aren't usable.
+    """
+    if not isinstance(child, dict) or not child.get("name"):
+        return None
+
+    name = str(child["name"])[:200]
+
+    age = child.get("age")
+    if isinstance(age, str):
+        try:
+            age = int(age)
+        except ValueError:
+            age = None
+    if age is not None and (age < 2 or age > 18):
+        age = None
+
+    reading_ability = str(child.get("reading_ability", ""))[:50] or None
+
+    return {"name": name, "age": age, "reading_ability": reading_ability}

--- a/app/tests/unit/test_action_processor.py
+++ b/app/tests/unit/test_action_processor.py
@@ -155,9 +155,7 @@ class TestInternalHandlerFallback:
         _setup_chat_repo(mock_action_chat_repo)
         _setup_chat_repo(mock_runtime_chat_repo)
 
-        mock_handlers["/v1/recommend"] = AsyncMock(
-            side_effect=ValueError("bad UUID")
-        )
+        mock_handlers["/v1/recommend"] = AsyncMock(side_effect=ValueError("bad UUID"))
 
         session = MockSession()
         node = _make_action_node(
@@ -180,9 +178,7 @@ class TestInternalHandlerFallback:
             },
         )
 
-        result = await action_processor.process(
-            mock_db, node, session, {"db": mock_db}
-        )
+        result = await action_processor.process(mock_db, node, session, {"db": mock_db})
 
         assert result["success"] is True
         assert result["variables"]["temp"]["book_count"] == 0
@@ -203,9 +199,7 @@ class TestInternalHandlerFallback:
         _setup_chat_repo(mock_action_chat_repo)
         _setup_chat_repo(mock_runtime_chat_repo)
 
-        mock_handlers["/v1/recommend"] = AsyncMock(
-            side_effect=ValueError("bad UUID")
-        )
+        mock_handlers["/v1/recommend"] = AsyncMock(side_effect=ValueError("bad UUID"))
 
         session = MockSession()
         node = _make_action_node(
@@ -225,9 +219,7 @@ class TestInternalHandlerFallback:
             },
         )
 
-        result = await action_processor.process(
-            mock_db, node, session, {"db": mock_db}
-        )
+        result = await action_processor.process(mock_db, node, session, {"db": mock_db})
         # The outer _execute_actions_sync catches the exception and sets success=False
         assert result["success"] is False
 
@@ -249,7 +241,7 @@ class TestInternalHandlerFallback:
 
         captured_args = {}
 
-        async def capture_handler(db, body, params):
+        async def capture_handler(db, body, params, context=None):
             captured_args["body"] = body
             captured_args["params"] = params
             return {"result": "ok"}
@@ -281,9 +273,7 @@ class TestInternalHandlerFallback:
             },
         )
 
-        result = await action_processor.process(
-            mock_db, node, session, {"db": mock_db}
-        )
+        result = await action_processor.process(mock_db, node, session, {"db": mock_db})
 
         assert result["success"] is True
         assert captured_args["body"] == {"name": "resolved", "school_id": None}
@@ -366,7 +356,10 @@ class TestEmitEvent:
 
         def sub_obj(obj, state):
             if isinstance(obj, dict):
-                return {k: sub_vars(v, state) if isinstance(v, str) else v for k, v in obj.items()}
+                return {
+                    k: sub_vars(v, state) if isinstance(v, str) else v
+                    for k, v in obj.items()
+                }
             if isinstance(obj, str):
                 return sub_vars(obj, state)
             return obj
@@ -396,9 +389,7 @@ class TestEmitEvent:
             "app.repositories.event_repository.event_repository"
         ) as patched_repo:
             patched_repo.acreate = mock_acreate
-            result = await processor.process(
-                mock_db, node, session, {"db": mock_db}
-            )
+            result = await processor.process(mock_db, node, session, {"db": mock_db})
 
         assert result["success"] is True
         call_kwargs = mock_acreate.call_args.kwargs
@@ -530,9 +521,7 @@ class TestEmitEvent:
         mock_school = Mock()
         mock_school.id = uuid.UUID(school_uuid)
 
-        session = MockSession(
-            state={"context": {"school_wriveted_id": school_uuid}}
-        )
+        session = MockSession(state={"context": {"school_wriveted_id": school_uuid}})
         node = _make_action_node(
             session.flow_id,
             {

--- a/app/tests/unit/test_internal_family_onboarding.py
+++ b/app/tests/unit/test_internal_family_onboarding.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for the ``/v1/onboarding/family`` internal handler.
+
+These are pure unit tests: the db session is an AsyncMock, so no real
+database is touched.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.internal_api_handlers import handle_family_onboarding
+
+
+@pytest.mark.asyncio
+async def test_family_onboarding_anonymous_session_creates_nothing():
+    """When the chat session has no session_user_id, do not create anything."""
+    mock_db = AsyncMock()
+
+    result = await handle_family_onboarding(
+        mock_db,
+        {"parent_name": "Jo", "children": [{"name": "Sam", "age": 8}]},
+        {},
+        context=None,
+    )
+
+    assert result["children_created"] == 0
+    mock_db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_family_onboarding_empty_context_creates_nothing():
+    """An empty context dict (no session_user_id key) is also anonymous."""
+    mock_db = AsyncMock()
+
+    result = await handle_family_onboarding(
+        mock_db,
+        {"parent_name": "Jo", "children": [{"name": "Sam", "age": 8}]},
+        {},
+        context={},
+    )
+
+    assert result["children_created"] == 0
+    mock_db.add.assert_not_called()


### PR DESCRIPTION
## Why

The family-signup chatflow created `PublicReader` profiles with **no `parent_id`** via the anonymous internal onboarding handler, orphaning them. Nothing tied a created reader to a chat session or user, and no claim path existed — so the "log in to link" step on the success page was a dead end. (School signup doesn't have this problem: it's auth-first and links records at creation.)

## What

Switch family signup to the **auth-first** pattern. The chat session already has an optional `user_id` and `/v1/chat/start` already stamps it from a bearer token, so the plumbing existed — it just wasn't used.

- Extract the promote-to-Parent + create-`parent_id`-linked-readers logic out of the authenticated `onboard_family` endpoint into **`onboarding_service.create_linked_family_readers`**, so the HTTP endpoint and the chatflow handler share one implementation.
- Thread the action-execution `context` (which carries `session_user_id`) through the internal-handler dispatch in `action_processor`.
- **`handle_family_onboarding`** now links created readers to the session user and promotes them to Parent. When the session is anonymous it creates **nothing** and asks the user to sign in — no more orphans.

Frontend counterpart (gates the page behind sign-in and sends the token): `hardbyte/huey-books-site` PR #60.

## Verification

- `ruff format` + `ruff check`: clean.
- Import smoke test: passes (with CI dummy env vars).
- `pytest app/tests/unit/test_action_processor.py app/tests/unit/test_internal_family_onboarding.py`: **23 passed** (incl. 2 new tests for the anonymous no-op path).
- Integration tests (`test_onboarding.py`) need Postgres — **not run locally** (no dedicated test DB available; the local :5432 belongs to another project). The `onboard_family` refactor relocates the *identical* promotion SQL into the service, so the authenticated path's behaviour is unchanged; **CI should run the DB-backed integration tests**.