### PR TITLE
Add Resend email backend (SendGrid replacement)

### DIFF
--- a/.cloudbuild/cloudbuild-main-branch.yaml
+++ b/.cloudbuild/cloudbuild-main-branch.yaml
@@ -135,6 +135,7 @@ steps:
         NIELSEN_CLIENT_ID=WrivetedWebServices,
         ENABLE_OTEL_GOOGLE_EXPORTER=True,
         WRIVETED_API_BASE_URL=https://api.wriveted.com,
+        EMAIL_PROVIDER=resend,
         OTEL_SERVICE_NAME=wriveted-api
       - >-
         --set-secrets=
@@ -147,6 +148,7 @@ steps:
         STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,
         SLACK_BOT_TOKEN=slack-wriveted-api-bot-token:latest,
         NIELSEN_PASSWORD=wriveted-nielsen-api-secret:latest,
+        RESEND_API_KEY=resend-api-key:latest,
         OPENAI_API_KEY=openai-api-key:latest
       - >-
         --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
@@ -178,6 +180,7 @@ steps:
         NIELSEN_CLIENT_ID=WrivetedWebServices,
         ENABLE_OTEL_GOOGLE_EXPORTER=True,
         WRIVETED_API_BASE_URL=https://api.wriveted.com,
+        EMAIL_PROVIDER=resend,
         OTEL_SERVICE_NAME=wriveted-api-internal
       - >-
         --set-secrets=
@@ -189,6 +192,7 @@ steps:
         STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,
         SLACK_BOT_TOKEN=slack-wriveted-api-bot-token:latest,
         NIELSEN_PASSWORD=wriveted-nielsen-api-secret:latest,
+        RESEND_API_KEY=resend-api-key:latest,
         OPENAI_API_KEY=openai-api-key:latest
       - >-
         --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS

--- a/app/config.py
+++ b/app/config.py
@@ -47,7 +47,11 @@ class Settings(BaseSettings):
     DATABASE_POOL_SIZE: int = 10
     DATABASE_MAX_OVERFLOW: int = 10
 
-    SENDGRID_API_KEY: str
+    # Email delivery. EMAIL_PROVIDER selects the backend ("resend" or
+    # "sendgrid"); keys are optional so the app boots without the unused one.
+    EMAIL_PROVIDER: str = "sendgrid"
+    SENDGRID_API_KEY: str = ""
+    RESEND_API_KEY: str = ""
 
     SHOPIFY_HMAC_SECRET: str
 

--- a/app/services/email_notification.py
+++ b/app/services/email_notification.py
@@ -14,12 +14,14 @@ reliable event-driven delivery.
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
+import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from structlog import get_logger
 
 from app.config import get_settings
 from app.schemas.sendgrid import SendGridEmailData
+from app.services.email_templates import render_email_template
 from app.services.event_outbox_service import EventOutboxService, EventPriority
 from app.services.exceptions import ServiceException
 
@@ -262,8 +264,8 @@ class EmailNotificationService:
                 )
                 return False  # Don't retry malformed payloads
 
-            # Use internal SendGrid method for sending
-            success = await self._send_email_via_sendgrid(email_data)
+            # Deliver via the configured provider (Resend or SendGrid)
+            success = await self._send_email(email_data)
 
             if success:
                 logger.info(
@@ -312,8 +314,8 @@ class EmailNotificationService:
             else:
                 email_data_dict = email_data
 
-            # Use internal SendGrid method
-            return await self._send_email_via_sendgrid(email_data_dict)
+            # Deliver via the configured provider (Resend or SendGrid)
+            return await self._send_email(email_data_dict)
 
         except Exception as e:
             logger.error(
@@ -322,6 +324,88 @@ class EmailNotificationService:
                 user_id=user_id,
                 error=str(e),
             )
+            return False
+
+    @staticmethod
+    def _to_dict(
+        email_data: Union[Dict[str, Any], SendGridEmailData],
+    ) -> Dict[str, Any]:
+        if hasattr(email_data, "model_dump"):
+            return email_data.model_dump()
+        if hasattr(email_data, "dict"):
+            return email_data.dict()
+        return email_data
+
+    async def _send_email(
+        self, email_data: Union[Dict[str, Any], SendGridEmailData]
+    ) -> bool:
+        """Deliver an email via the provider selected by EMAIL_PROVIDER."""
+        data = self._to_dict(email_data)
+        provider = (config.EMAIL_PROVIDER or "sendgrid").lower()
+        if provider == "resend":
+            return await self._send_email_via_resend(data)
+        return await self._send_email_via_sendgrid(data)
+
+    async def _send_email_via_resend(self, data: Dict[str, Any]) -> bool:
+        """Send via the Resend HTTP API (async, non-blocking).
+
+        Uses html_content when present; otherwise renders a known legacy
+        template id to HTML. Returns True on a 2xx response.
+        """
+        if not config.RESEND_API_KEY:
+            logger.warning("Resend API key not configured")
+            return False
+
+        html = data.get("html_content")
+        if not html and data.get("template_id"):
+            html = render_email_template(data["template_id"], data.get("template_data"))
+        if not html:
+            logger.error(
+                "No HTML or known template for Resend email",
+                subject=data.get("subject", ""),
+                template_id=data.get("template_id"),
+            )
+            return False
+
+        from_email = data.get("from_email") or config.BROADCAST_FROM_EMAIL
+        from_name = data.get("from_name")
+        sender = f"{from_name} <{from_email}>" if from_name else from_email
+
+        payload: Dict[str, Any] = {
+            "from": sender,
+            "to": data.get("to_emails"),
+            "subject": data.get("subject") or "",
+            "html": html,
+        }
+        if reply_to := data.get("reply_to"):
+            payload["reply_to"] = reply_to
+        if headers := data.get("headers"):
+            payload["headers"] = headers
+
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(
+                    "https://api.resend.com/emails",
+                    headers={"Authorization": f"Bearer {config.RESEND_API_KEY}"},
+                    json=payload,
+                )
+
+            success = response.status_code in (200, 201)
+            if success:
+                logger.info(
+                    "Email sent via Resend",
+                    subject=payload["subject"],
+                    to_emails=payload["to"],
+                )
+            else:
+                logger.warning(
+                    "Resend returned non-2xx status",
+                    status_code=response.status_code,
+                    body=response.text[:500],
+                )
+            return success
+        except Exception as e:
+            logger.error("Resend API error", error=str(e))
             return False
 
     async def _send_email_via_sendgrid(

--- a/app/services/email_templates.py
+++ b/app/services/email_templates.py
@@ -1,0 +1,94 @@
+"""Inline HTML for transactional emails.
+
+SendGrid hosted these as dynamic templates (``d-...`` ids) keyed by
+``template_id``. Resend has no server-side templates, so we render equivalent
+HTML here from the same ``template_data`` the call sites already pass. Keep the
+markup simple and inline-styled for broad email-client support.
+
+The copy here is a functional port, not a design pass — worth a review by
+someone who owns the brand voice.
+"""
+
+from html import escape
+from typing import Callable, Optional
+
+_FONT = "font-family: Arial, Helvetica, sans-serif; font-size: 15px; line-height: 1.5; color: #1f1f1f;"
+
+
+def _shell(body_html: str) -> str:
+    """Wrap body content in the shared Huey Books email frame."""
+    return (
+        f'<div style="{_FONT} max-width: 600px; margin: 0 auto;">'
+        f"{body_html}"
+        '<hr style="border:none;border-top:1px solid #eee;margin:24px 0 12px;">'
+        '<p style="font-size:12px;color:#888;">Huey Books</p>'
+        "</div>"
+    )
+
+
+def _button(href: str, label: str) -> str:
+    return (
+        f'<p style="margin:24px 0;"><a href="{escape(href, quote=True)}" '
+        'style="background:#5b3fd6;color:#fff;text-decoration:none;padding:12px 20px;'
+        'border-radius:6px;display:inline-block;">'
+        f"{escape(label)}</a></p>"
+    )
+
+
+def _welcome(d: dict) -> str:
+    name = escape(str(d.get("name") or "there"))
+    children = escape(str(d.get("children_string") or "your reader"))
+    return _shell(
+        f"<h2>Welcome to Huey Books!</h2>"
+        f"<p>Hi {name},</p>"
+        f"<p>Thanks for joining Huey Books. We're excited to help {children} "
+        "discover books they'll love.</p>"
+        "<p>Happy reading,<br>The Huey Books team</p>"
+    )
+
+
+def _subscription(d: dict) -> str:
+    name = escape(str(d.get("name") or "there"))
+    return _shell(
+        "<h2>Your Huey Books Membership</h2>"
+        f"<p>Hi {name},</p>"
+        "<p>Thank you for becoming a Huey Books member! Your subscription is "
+        "active and you now have full access.</p>"
+        "<p>If you have any questions just reply to this email.</p>"
+        "<p>Happy reading,<br>The Huey Books team</p>"
+    )
+
+
+def _reading_feedback(d: dict) -> str:
+    supporter = escape(str(d.get("supporter_name") or "there"))
+    reader = escape(str(d.get("reader_name") or "your reader"))
+    book = escape(str(d.get("book_title") or "a book"))
+    emoji = escape(str(d.get("emoji") or ""))
+    descriptor = escape(str(d.get("descriptor") or ""))
+    url = d.get("encoded_url")
+    cta = _button(url, "See their reading") if url else ""
+    return _shell(
+        f"<h2>{reader} has done some reading! {emoji}</h2>"
+        f"<p>Hi {supporter},</p>"
+        f"<p>{reader} just logged some reading of <strong>{book}</strong>"
+        + (f" and found it {descriptor}." if descriptor else ".")
+        + "</p>"
+        + cta
+        + "<p>Happy reading,<br>The Huey Books team</p>"
+    )
+
+
+# Maps the legacy SendGrid dynamic-template ids to their HTML renderers.
+_RENDERERS: dict[str, Callable[[dict], str]] = {
+    "d-3655b189b9a8427d99fe02cf7e7f3fd9": _welcome,
+    "d-fa829ecc76fc4e37ab4819abb6e0d188": _subscription,
+    "d-841938d74d9142509af934005ad6e3ed": _reading_feedback,
+}
+
+
+def render_email_template(template_id: str, data: Optional[dict]) -> Optional[str]:
+    """Render HTML for a known legacy template id, or None if unknown."""
+    renderer = _RENDERERS.get(template_id)
+    if renderer is None:
+        return None
+    return renderer(data or {})

--- a/app/tests/unit/test_email_notification_service.py
+++ b/app/tests/unit/test_email_notification_service.py
@@ -270,10 +270,11 @@ class TestEmailNotificationService:
         assert result is True
         service._send_email_via_sendgrid.assert_called_once()
 
-        # Verify the email data was properly reconstructed
+        # Verify the email data was passed through to the provider adapter.
+        # The dispatcher normalises to a dict so any backend can consume it.
         call_args = service._send_email_via_sendgrid.call_args[0][0]
-        assert call_args.from_email == "test@example.com"
-        assert call_args.to_emails == ["recipient@example.com"]
+        assert call_args["from_email"] == "test@example.com"
+        assert call_args["to_emails"] == ["recipient@example.com"]
 
     @pytest.mark.asyncio
     async def test_process_outbox_email_notification_invalid_payload(self, service):

--- a/app/tests/unit/test_resend_email.py
+++ b/app/tests/unit/test_resend_email.py
@@ -1,0 +1,154 @@
+"""Tests for the Resend email backend and the ported inline templates."""
+
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from app.services import email_notification
+from app.services.email_notification import EmailNotificationService
+from app.services.email_templates import render_email_template
+
+WELCOME_ID = "d-3655b189b9a8427d99fe02cf7e7f3fd9"
+SUBSCRIPTION_ID = "d-fa829ecc76fc4e37ab4819abb6e0d188"
+FEEDBACK_ID = "d-841938d74d9142509af934005ad6e3ed"
+
+
+def _service() -> EmailNotificationService:
+    return EmailNotificationService(Mock())
+
+
+# --- template rendering ---
+
+
+def test_render_known_templates_return_html():
+    assert "Welcome to Huey Books" in render_email_template(WELCOME_ID, {"name": "Sam"})
+    assert "Membership" in render_email_template(SUBSCRIPTION_ID, {"name": "Sam"})
+    fb = render_email_template(
+        FEEDBACK_ID,
+        {
+            "supporter_name": "Sam",
+            "reader_name": "Alex",
+            "book_title": "Matilda",
+            "encoded_url": "https://hueybooks.com/reader-feedback/?t=abc",
+        },
+    )
+    assert "Alex" in fb and "Matilda" in fb
+    assert "https://hueybooks.com/reader-feedback/?t=abc" in fb  # CTA link present
+
+
+def test_render_escapes_untrusted_values():
+    html = render_email_template(WELCOME_ID, {"name": "<script>x</script>"})
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_render_unknown_template_returns_none():
+    assert render_email_template("d-unknown", {"name": "x"}) is None
+
+
+# --- Resend send path ---
+
+
+def _mock_httpx(monkeypatch, handler):
+    """Route the service's httpx.AsyncClient through a MockTransport."""
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resend_send_builds_payload_and_succeeds(monkeypatch):
+    monkeypatch.setattr(email_notification.config, "RESEND_API_KEY", "re_test")
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        import json
+
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"id": "email_123"})
+
+    _mock_httpx(monkeypatch, handler)
+
+    ok = await _service()._send_email_via_resend(
+        {
+            "from_email": "hello@hueybooks.com",
+            "from_name": "Huey Books",
+            "to_emails": ["someone@example.com"],
+            "subject": "Hi",
+            "html_content": "<p>Hello</p>",
+            "reply_to": "hello@hueybooks.com",
+            "headers": {"List-Unsubscribe": "<https://x/u>"},
+        }
+    )
+
+    assert ok is True
+    assert captured["url"] == "https://api.resend.com/emails"
+    assert captured["auth"] == "Bearer re_test"
+    body = captured["body"]
+    assert body["from"] == "Huey Books <hello@hueybooks.com>"
+    assert body["to"] == ["someone@example.com"]
+    assert body["html"] == "<p>Hello</p>"
+    assert body["reply_to"] == "hello@hueybooks.com"
+    assert body["headers"]["List-Unsubscribe"] == "<https://x/u>"
+
+
+@pytest.mark.asyncio
+async def test_resend_renders_template_when_no_html(monkeypatch):
+    monkeypatch.setattr(email_notification.config, "RESEND_API_KEY", "re_test")
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(201, json={"id": "email_456"})
+
+    _mock_httpx(monkeypatch, handler)
+
+    ok = await _service()._send_email_via_resend(
+        {
+            "to_emails": ["parent@example.com"],
+            "subject": "Your Huey Books Membership",
+            "template_id": SUBSCRIPTION_ID,
+            "template_data": {"name": "Sam"},
+        }
+    )
+    assert ok is True
+    assert "Membership" in captured["body"]["html"]
+
+
+@pytest.mark.asyncio
+async def test_resend_returns_false_without_key(monkeypatch):
+    monkeypatch.setattr(email_notification.config, "RESEND_API_KEY", "")
+    ok = await _service()._send_email_via_resend(
+        {"to_emails": ["a@b.com"], "html_content": "<p>x</p>"}
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_resend_returns_false_on_non_2xx(monkeypatch):
+    monkeypatch.setattr(email_notification.config, "RESEND_API_KEY", "re_test")
+    _mock_httpx(monkeypatch, lambda request: httpx.Response(422, json={"error": "bad"}))
+    ok = await _service()._send_email_via_resend(
+        {"to_emails": ["a@b.com"], "subject": "x", "html_content": "<p>x</p>"}
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_to_resend(monkeypatch):
+    monkeypatch.setattr(email_notification.config, "EMAIL_PROVIDER", "resend")
+    monkeypatch.setattr(email_notification.config, "RESEND_API_KEY", "re_test")
+    _mock_httpx(monkeypatch, lambda request: httpx.Response(200, json={"id": "x"}))
+    ok = await _service()._send_email(
+        {"to_emails": ["a@b.com"], "subject": "x", "html_content": "<p>x</p>"}
+    )
+    assert ok is True


### PR DESCRIPTION
The SendGrid account was terminated (unpaid invoices → HTTP 401 on every send), so this adds **Resend** as the email delivery backend and cuts prod over to it.

## Design

- **`EMAIL_PROVIDER`** config selects the backend. The SendGrid path is untouched and reversible (flip the env var back).
- **`_send_email`** dispatcher routes to `_send_email_via_resend` or `_send_email_via_sendgrid`.
- **`_send_email_via_resend`** uses `httpx.AsyncClient` (async, **non-blocking** — unlike the old sync SendGrid SDK call on the event loop). Supports `html_content` (broadcasts) and renders legacy dynamic-template ids to inline HTML.
- **`email_templates.py`** ports the 3 SendGrid dynamic templates (welcome, subscription welcome, reading feedback) to inline HTML. ⚠️ Functional port — **worth a brand/design review**.
- `SENDGRID_API_KEY` is now optional so the app boots without it.
- **Deploy config** sets `EMAIL_PROVIDER=resend` + the `RESEND_API_KEY` secret on both prod services. The `resend-api-key` secret already exists in Secret Manager (value not in code). Dev services are left as-is.

## Tests

8 unit tests (`test_resend_email.py`): template rendering + HTML escaping, Resend payload construction, template fallback, missing-key/non-2xx handling, dispatch routing. Plus 34 email/broadcast/outbox integration tests still green (dispatcher change is neutral on the existing path).

## ⚠️ Merge = cutover

Merging auto-deploys and flips prod to Resend, so **merge only once Resend shows hueybooks.com as Verified**. DNS (DKIM/SPF) is tracked in hardbyte-iac PR #6. After deploy, re-send a broadcast test to confirm; the earlier failed outbox events retry automatically.