### PR TITLE
Flip dev services to Resend

### DIFF
--- a/.cloudbuild/cloudbuild-main-branch.yaml
+++ b/.cloudbuild/cloudbuild-main-branch.yaml
@@ -47,6 +47,7 @@ steps:
         NIELSEN_API_URL=https://ws.nielsenbookdataonline.com/BDOLRest/RESTwebServices/BDOLrequest,
         NIELSEN_CLIENT_ID=WrivetedWebServices,
         WRIVETED_API_BASE_URL=https://wriveted-api-development-main-branch-lg5ntws4da-ts.a.run.app,
+        EMAIL_PROVIDER=resend,
         OTEL_SERVICE_NAME=nonprod-api
       - >-
         --set-secrets=
@@ -59,6 +60,7 @@ steps:
         STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,
         SLACK_BOT_TOKEN=slack-wriveted-api-bot-token:latest,
         NIELSEN_PASSWORD=wriveted-nielsen-api-secret:latest,
+        RESEND_API_KEY=resend-api-key:latest,
         OPENAI_API_KEY=openai-api-key:latest
       - >-
         --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
@@ -91,6 +93,7 @@ steps:
         NIELSEN_CLIENT_ID=WrivetedWebServices,
         ENABLE_OTEL_GOOGLE_EXPORTER=True,
         WRIVETED_API_BASE_URL=https://wriveted-api-development-main-branch-lg5ntws4da-ts.a.run.app,
+        EMAIL_PROVIDER=resend,
         OTEL_SERVICE_NAME=nonprod-api-internal
       - >-
         --set-secrets=
@@ -102,6 +105,7 @@ steps:
         STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,
         SLACK_BOT_TOKEN=slack-wriveted-api-bot-token:latest,
         NIELSEN_PASSWORD=wriveted-nielsen-api-secret:latest,
+        RESEND_API_KEY=resend-api-key:latest,
         OPENAI_API_KEY=openai-api-key:latest
       - >-
         --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS


### PR DESCRIPTION
Sets `EMAIL_PROVIDER=resend` + the `RESEND_API_KEY` secret on the two dev main-branch services, matching the prod cutover (#679). Same runtime SA (already has secret access). Cloudbuild-only change.