### PR TITLE
Fix background tasks using the request-scoped DB session

### DIFF
--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -48,6 +48,8 @@ from app.schemas.collection import (
     CollectionUpdateSummaryResponse,
 )
 from app.schemas.pagination import Pagination
+from app.services.account_refs import get_account_ref
+from app.services.background_events import record_booklist_collection_comparison_event
 from app.services.collection_service import CollectionService
 from app.services.collections import (
     get_collection_info_with_criteria,
@@ -289,17 +291,14 @@ async def get_collection_booklist_intersection(
     )
     common_work_ids = {item.work_id for item in common_collection_items}
 
+    account_type, account_id = get_account_ref(account)
     background_tasks.add_task(
-        event_repository.create,
-        session,
-        title="Compared booklist and collection",
-        info={
-            "items_in_common": len(common_collection_items),
-            "collection_id": str(collection.id),
-            "booklist_id": str(booklist.id),
-        },
-        collection=collection,
-        account=account,
+        record_booklist_collection_comparison_event,
+        str(collection.id),
+        str(booklist.id),
+        len(common_collection_items),
+        account_type,
+        account_id,
     )
 
     return CollectionBookListIntersection(

--- a/app/api/commerce.py
+++ b/app/api/commerce.py
@@ -27,11 +27,12 @@ from app.schemas.sendgrid import (
     SendGridEmailData,
 )
 from app.schemas.shopify import ShopifyEventRoot
+from app.services.account_refs import get_account_ref
 from app.services.background_tasks import queue_background_task
 from app.services.commerce import (
     get_sendgrid_api,
-    process_shopify_order,
-    upsert_sendgrid_contact,
+    process_shopify_order_background,
+    upsert_sendgrid_contact_background,
     validate_sendgrid_custom_fields,
 )
 
@@ -47,7 +48,6 @@ async def upsert_contact(
     background_tasks: BackgroundTasks,
     custom_fields: list[SendGridCustomField] = Body(default=None),
     account=Depends(get_current_active_superuser_or_backend_service_account),
-    session: Session = Depends(get_session),
     increment_children: bool | None = Query(False),
     sg: SendGridAPIClient = Depends(get_sendgrid_api),
 ):
@@ -64,17 +64,21 @@ async def upsert_contact(
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e))
 
-        data_dict = data.model_dump()
         payload = CustomSendGridContactData(
-            email=data.email, **data_dict, custom_fields=validated_fields
+            **data.model_dump(), custom_fields=validated_fields
         )
 
     else:
-        payload = data
+        payload = CustomSendGridContactData(**data.model_dump(), custom_fields=None)
 
     # schedule the update
+    account_type, account_id = get_account_ref(account)
     background_tasks.add_task(
-        upsert_sendgrid_contact, payload, session, account, sg, increment_children
+        upsert_sendgrid_contact_background,
+        payload,
+        account_type,
+        account_id,
+        increment_children,
     )
 
     return Response(status_code=202, content="Contact upsert queued.")
@@ -117,14 +121,12 @@ async def send_email(
 async def create_shopify_order(
     data: ShopifyEventRoot,
     background_tasks: BackgroundTasks,
-    session: Session = Depends(get_session),
-    sg: SendGridAPIClient = Depends(get_sendgrid_api),
 ):
     """
     Endpoint for the Webhook called by Shopify when a customer places an order.
     Upserts equivalent SendGrid contact with basic info about the order, and logs an event with the details.
     """
-    background_tasks.add_task(process_shopify_order, data, sg, session)
+    background_tasks.add_task(process_shopify_order_background, data)
 
     return Response(status_code=200, content="Thanks Shopify")
 

--- a/app/services/account_refs.py
+++ b/app/services/account_refs.py
@@ -1,0 +1,33 @@
+from typing import Literal
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models.service_account import ServiceAccount
+from app.models.user import User
+
+AccountRefType = Literal["user", "service_account"]
+
+
+def get_account_ref(
+    account: User | ServiceAccount | None,
+) -> tuple[AccountRefType | None, UUID | None]:
+    if isinstance(account, User):
+        return "user", account.id
+    if isinstance(account, ServiceAccount):
+        return "service_account", account.id
+    return None, None
+
+
+def load_account_ref(
+    session: Session, account_type: AccountRefType | None, account_id: UUID | None
+) -> User | ServiceAccount | None:
+    if account_type is None or account_id is None:
+        return None
+
+    if account_type == "user":
+        return session.get(User, account_id)
+    if account_type == "service_account":
+        return session.get(ServiceAccount, account_id)
+
+    return None

--- a/app/services/background_events.py
+++ b/app/services/background_events.py
@@ -1,0 +1,27 @@
+from uuid import UUID
+
+from app.db.session import get_session_maker
+from app.repositories.event_repository import event_repository
+from app.services.account_refs import AccountRefType, load_account_ref
+
+
+def record_booklist_collection_comparison_event(
+    collection_id: str,
+    booklist_id: str,
+    items_in_common: int,
+    account_type: AccountRefType | None = None,
+    account_id: UUID | None = None,
+):
+    Session = get_session_maker()
+    with Session() as session:
+        account = load_account_ref(session, account_type, account_id)
+        event_repository.create(
+            session=session,
+            title="Compared booklist and collection",
+            info={
+                "items_in_common": items_in_common,
+                "collection_id": collection_id,
+                "booklist_id": booklist_id,
+            },
+            account=account,
+        )

--- a/app/services/commerce.py
+++ b/app/services/commerce.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from json import loads
 from typing import Container, ItemsView, Union
 from urllib.error import HTTPError
+from uuid import UUID
 
 from pydantic import EmailStr, parse_obj_as
 from python_http_client.client import Response
@@ -15,6 +16,7 @@ from twilio.rest import Client as TwilioClient
 
 from app import crud
 from app.config import get_settings
+from app.db.session import get_session_maker
 from app.models.service_account import ServiceAccount
 from app.models.user import User
 from app.schemas.sendgrid import (
@@ -24,6 +26,7 @@ from app.schemas.sendgrid import (
     SendGridEmailData,
 )
 from app.schemas.shopify import ShopifyEventRoot
+from app.services.account_refs import AccountRefType, load_account_ref
 
 logger = get_logger()
 config = get_settings()
@@ -211,6 +214,20 @@ def upsert_sendgrid_contact(
     )
 
 
+def upsert_sendgrid_contact_background(
+    data: CustomSendGridContactData,
+    account_type: AccountRefType | None,
+    account_id: UUID | None,
+    increment_children: bool = False,
+):
+    Session = get_session_maker()
+    with Session() as session:
+        account = load_account_ref(session, account_type, account_id)
+        upsert_sendgrid_contact(
+            data, session, account, get_sendgrid_api(), increment_children
+        )
+
+
 def send_sendgrid_email(
     data: SendGridEmailData,
     session: Session,
@@ -307,3 +324,9 @@ def process_shopify_order(
         description="A customer placed an order on the HueyBooks Shopify store",
         info={"shopify_data": json.loads(json.dumps(data.dict(), default=str))},
     )
+
+
+def process_shopify_order_background(data: ShopifyEventRoot):
+    Session = get_session_maker()
+    with Session() as session:
+        process_shopify_order(data, get_sendgrid_api(), session)

--- a/app/services/commerce.py
+++ b/app/services/commerce.py
@@ -186,8 +186,10 @@ def upsert_sendgrid_contact(
         )
 
     try:
+        # exclude_none so unset optionals (incl. custom_fields) are omitted
+        # rather than sent as null, which SendGrid's contacts schema rejects.
         response = sg.client.marketing.contacts.put(
-            request_body={"contacts": [data.dict()]}
+            request_body={"contacts": [data.model_dump(exclude_none=True)]}
         )
         output = {
             "code": str(response.status_code),

--- a/app/tests/unit/test_background_task_sessions.py
+++ b/app/tests/unit/test_background_task_sessions.py
@@ -1,0 +1,165 @@
+import os
+from datetime import datetime
+from unittest.mock import MagicMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+
+os.environ.setdefault("POSTGRESQL_PASSWORD", "test-password")
+os.environ.setdefault("SENDGRID_API_KEY", "test-sendgrid-key")
+os.environ.setdefault("SHOPIFY_HMAC_SECRET", "test-shopify-secret")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+
+from app.api import commerce as commerce_api
+from app.models.service_account import ServiceAccount, ServiceAccountType
+from app.schemas.sendgrid import CustomSendGridContactData, SendGridContactData
+from app.schemas.shopify import ShopifyEventRoot
+from app.services import background_events
+from app.services import commerce as commerce_service
+
+
+def _session_maker_with_context():
+    session = Mock(name="fresh_session")
+    context = MagicMock(name="session_context")
+    context.__enter__.return_value = session
+    session_maker = Mock(name="session_maker", return_value=context)
+    return session_maker, context, session
+
+
+@pytest.mark.asyncio
+async def test_upsert_contact_schedules_session_owning_background_task():
+    account = ServiceAccount(
+        id=uuid4(),
+        name="backend",
+        type=ServiceAccountType.BACKEND,
+    )
+    background_tasks = Mock()
+    data = SendGridContactData(email="reader@example.com")
+
+    response = await commerce_api.upsert_contact(
+        data=data,
+        background_tasks=background_tasks,
+        custom_fields=None,
+        account=account,
+        increment_children=True,
+        sg=Mock(name="sendgrid"),
+    )
+
+    assert response.status_code == 202
+    background_tasks.add_task.assert_called_once()
+    func, payload, account_type, account_id, increment_children = (
+        background_tasks.add_task.call_args.args
+    )
+    assert func is commerce_api.upsert_sendgrid_contact_background
+    assert isinstance(payload, CustomSendGridContactData)
+    assert payload.email == data.email
+    assert payload.custom_fields is None
+    assert account_type == "service_account"
+    assert account_id == account.id
+    assert increment_children is True
+
+
+@pytest.mark.asyncio
+async def test_shopify_order_schedules_session_owning_background_task():
+    background_tasks = Mock()
+    data = ShopifyEventRoot(
+        id=123,
+        email="buyer@example.com",
+        created_at=datetime(2026, 1, 1),
+        customer=None,
+        total_price="42.00",
+    )
+
+    response = await commerce_api.create_shopify_order(
+        data=data,
+        background_tasks=background_tasks,
+    )
+
+    assert response.status_code == 200
+    background_tasks.add_task.assert_called_once_with(
+        commerce_api.process_shopify_order_background, data
+    )
+
+
+def test_upsert_sendgrid_contact_background_opens_fresh_session():
+    session_maker, context, fresh_session = _session_maker_with_context()
+    account_id = uuid4()
+    account = Mock(name="account")
+    payload = CustomSendGridContactData(email="reader@example.com", custom_fields=None)
+    sg = Mock(name="sendgrid")
+
+    with (
+        patch.object(
+            commerce_service, "get_session_maker", return_value=session_maker
+        ) as get_session_maker,
+        patch.object(
+            commerce_service, "load_account_ref", return_value=account
+        ) as load_account_ref,
+        patch.object(commerce_service, "get_sendgrid_api", return_value=sg),
+        patch.object(commerce_service, "upsert_sendgrid_contact") as upsert_contact,
+    ):
+        commerce_service.upsert_sendgrid_contact_background(
+            payload, "service_account", account_id, True
+        )
+
+    get_session_maker.assert_called_once_with()
+    session_maker.assert_called_once_with()
+    load_account_ref.assert_called_once_with(
+        fresh_session, "service_account", account_id
+    )
+    upsert_contact.assert_called_once_with(payload, fresh_session, account, sg, True)
+    context.__exit__.assert_called_once()
+
+
+def test_shopify_order_background_opens_fresh_session():
+    session_maker, context, fresh_session = _session_maker_with_context()
+    data = Mock(name="shopify_order")
+    sg = Mock(name="sendgrid")
+
+    with (
+        patch.object(
+            commerce_service, "get_session_maker", return_value=session_maker
+        ) as get_session_maker,
+        patch.object(commerce_service, "get_sendgrid_api", return_value=sg),
+        patch.object(commerce_service, "process_shopify_order") as process_order,
+    ):
+        commerce_service.process_shopify_order_background(data)
+
+    get_session_maker.assert_called_once_with()
+    session_maker.assert_called_once_with()
+    process_order.assert_called_once_with(data, sg, fresh_session)
+    context.__exit__.assert_called_once()
+
+
+def test_booklist_collection_comparison_background_event_opens_fresh_session():
+    session_maker, context, fresh_session = _session_maker_with_context()
+    account_id = uuid4()
+    account = Mock(name="account")
+
+    with (
+        patch.object(
+            background_events, "get_session_maker", return_value=session_maker
+        ) as get_session_maker,
+        patch.object(
+            background_events, "load_account_ref", return_value=account
+        ) as load_account_ref,
+        patch.object(background_events.event_repository, "create") as create_event,
+    ):
+        background_events.record_booklist_collection_comparison_event(
+            "collection-1", "booklist-1", 3, "user", account_id
+        )
+
+    get_session_maker.assert_called_once_with()
+    session_maker.assert_called_once_with()
+    load_account_ref.assert_called_once_with(fresh_session, "user", account_id)
+    create_event.assert_called_once_with(
+        session=fresh_session,
+        title="Compared booklist and collection",
+        info={
+            "items_in_common": 3,
+            "collection_id": "collection-1",
+            "booklist_id": "booklist-1",
+        },
+        account=account,
+    )
+    context.__exit__.assert_called_once()


### PR DESCRIPTION
FastAPI `BackgroundTasks` run **after** the response is sent, by which point the request-scoped session (`get_session`) is closed. Several tasks were scheduled with that session (and ORM `account` objects) passed in, which is unsafe (closed/detached session in the task).

Fix: schedule **session-owning** background tasks — pass account *references* (type + id), and open a fresh session inside the task.

- `app/services/account_refs.py` — `get_account_ref(account) -> (type, id)` / `load_account_ref(session, type, id)`.
- `app/services/background_events.py` — records the booklist↔collection comparison event in its own session.
- `commerce` upsert-contact + shopify-order, and `collections` booklist-intersection, now schedule the session-owning variants.

Origin: these were uncommitted WIP in a stale worktree; evaluated and rebased onto current `main` (the `#676` `send_email` commit is preserved). Discarded alongside them: an ASCII-whitespace-only `chatbot-system.md` diff and a trivial `stripe.md` de-brand (left for the de-Wriveting pass).

## Tests
`app/tests/unit/test_background_task_sessions.py` (5) — asserts the endpoints schedule the session-owning tasks. Lint clean. Local integration was blocked by a concurrent worktree holding port 5432; **CI runs the full integration suite** here.