### PR TITLE
Add 'contribute a month' school contribution feature

### DIFF
--- a/.cloudbuild/cloudbuild-main-branch.yaml
+++ b/.cloudbuild/cloudbuild-main-branch.yaml
@@ -64,6 +64,7 @@ steps:
         SLACK_BOT_TOKEN=slack-wriveted-api-bot-token:latest,
         NIELSEN_PASSWORD=wriveted-nielsen-api-secret:latest,
         RESEND_API_KEY=resend-api-key:latest,
+        STAFF_ALERT_EMAILS=staff-alert-emails:latest,
         OPENAI_API_KEY=openai-api-key:latest
       - >-
         --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
@@ -112,6 +113,7 @@ steps:
         SLACK_BOT_TOKEN=slack-wriveted-api-bot-token:latest,
         NIELSEN_PASSWORD=wriveted-nielsen-api-secret:latest,
         RESEND_API_KEY=resend-api-key:latest,
+        STAFF_ALERT_EMAILS=staff-alert-emails:latest,
         OPENAI_API_KEY=openai-api-key:latest
       - >-
         --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
@@ -162,6 +164,7 @@ steps:
         SLACK_BOT_TOKEN=slack-wriveted-api-bot-token:latest,
         NIELSEN_PASSWORD=wriveted-nielsen-api-secret:latest,
         RESEND_API_KEY=resend-api-key:latest,
+        STAFF_ALERT_EMAILS=staff-alert-emails:latest,
         OPENAI_API_KEY=openai-api-key:latest
       - >-
         --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
@@ -209,6 +212,7 @@ steps:
         SLACK_BOT_TOKEN=slack-wriveted-api-bot-token:latest,
         NIELSEN_PASSWORD=wriveted-nielsen-api-secret:latest,
         RESEND_API_KEY=resend-api-key:latest,
+        STAFF_ALERT_EMAILS=staff-alert-emails:latest,
         OPENAI_API_KEY=openai-api-key:latest
       - >-
         --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS

--- a/.cloudbuild/cloudbuild-main-branch.yaml
+++ b/.cloudbuild/cloudbuild-main-branch.yaml
@@ -49,6 +49,8 @@ steps:
         WRIVETED_API_BASE_URL=https://wriveted-api-development-main-branch-lg5ntws4da-ts.a.run.app,
         EMAIL_PROVIDER=resend,
         STRIPE_SCHOOL_PRICE_IDS=price_1TtloSJn6IrlrOboBreHYarj,
+        STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS=price_1Ttm0oJn6IrlrOboSQnwyA6D,
+        SCHOOL_CONTRIBUTION_MONTHLY_CENTS=2000,
         OTEL_SERVICE_NAME=nonprod-api
       - >-
         --set-secrets=
@@ -96,6 +98,8 @@ steps:
         WRIVETED_API_BASE_URL=https://wriveted-api-development-main-branch-lg5ntws4da-ts.a.run.app,
         EMAIL_PROVIDER=resend,
         STRIPE_SCHOOL_PRICE_IDS=price_1TtloSJn6IrlrOboBreHYarj,
+        STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS=price_1Ttm0oJn6IrlrOboSQnwyA6D,
+        SCHOOL_CONTRIBUTION_MONTHLY_CENTS=2000,
         OTEL_SERVICE_NAME=nonprod-api-internal
       - >-
         --set-secrets=
@@ -143,6 +147,8 @@ steps:
         WRIVETED_API_BASE_URL=https://api.wriveted.com,
         EMAIL_PROVIDER=resend,
         STRIPE_SCHOOL_PRICE_IDS=price_1TtloSJn6IrlrOboBreHYarj,
+        STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS=price_1Ttm0oJn6IrlrOboSQnwyA6D,
+        SCHOOL_CONTRIBUTION_MONTHLY_CENTS=2000,
         OTEL_SERVICE_NAME=wriveted-api
       - >-
         --set-secrets=
@@ -189,6 +195,8 @@ steps:
         WRIVETED_API_BASE_URL=https://api.wriveted.com,
         EMAIL_PROVIDER=resend,
         STRIPE_SCHOOL_PRICE_IDS=price_1TtloSJn6IrlrOboBreHYarj,
+        STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS=price_1Ttm0oJn6IrlrOboSQnwyA6D,
+        SCHOOL_CONTRIBUTION_MONTHLY_CENTS=2000,
         OTEL_SERVICE_NAME=wriveted-api-internal
       - >-
         --set-secrets=

--- a/alembic/versions/a1c0n7r1b8e1_add_stripe_contribution_receipts.py
+++ b/alembic/versions/a1c0n7r1b8e1_add_stripe_contribution_receipts.py
@@ -1,0 +1,53 @@
+"""add stripe_contribution_receipts idempotency table
+
+Revision ID: a1c0n7r1b8e1
+Revises: c1a2m3p4a5n6
+Create Date: 2026-07-16 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1c0n7r1b8e1"
+down_revision = "c1a2m3p4a5n6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "stripe_contribution_receipts",
+        sa.Column("checkout_session_id", sa.String(), nullable=False),
+        sa.Column("school_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("amount_total", sa.Integer(), nullable=True),
+        sa.Column("currency", sa.String(), nullable=True),
+        sa.Column("crediting", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        # The primary key on the checkout session id is the idempotency guard:
+        # the webhook claims a session with INSERT ... ON CONFLICT DO NOTHING.
+        sa.PrimaryKeyConstraint(
+            "checkout_session_id", name="pk_stripe_contribution_receipts"
+        ),
+    )
+    op.create_index(
+        "ix_stripe_contribution_receipts_school_id",
+        "stripe_contribution_receipts",
+        ["school_id"],
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "ix_stripe_contribution_receipts_school_id",
+        table_name="stripe_contribution_receipts",
+    )
+    op.drop_table("stripe_contribution_receipts")

--- a/app/api/internal/__init__.py
+++ b/app/api/internal/__init__.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, List, Optional
 from uuid import UUID
 
@@ -5,7 +6,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from pydantic_settings import BaseSettings
 from sendgrid import SendGridAPIClient
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 from structlog import get_logger
 from twilio.rest import Client as TwilioClient
@@ -17,6 +18,8 @@ from app.api.dependencies.async_db_dep import DBSessionDep
 from app.api.internal.tasks import router as tasks_router
 from app.db.session import get_session
 from app.models.event import EventSlackChannel
+from app.models.school import School, SchoolState
+from app.models.subscription import Subscription
 from app.repositories.chat_repository import chat_repo
 from app.repositories.service_account_repository import service_account_repository
 from app.repositories.work_repository import work_repository
@@ -32,7 +35,7 @@ from app.services.commerce import (
 from app.services.events import handle_event_to_slack_alert, process_events
 from app.services.hydration import hydrate_bulk
 from app.services.labelling import label_and_update_work
-from app.services.stripe_events import process_stripe_event
+from app.services.stripe_events import CONTRIBUTION_GRANT_SOURCE, process_stripe_event
 
 
 class CloudRunEnvironment(BaseSettings):
@@ -299,3 +302,75 @@ async def handle_refresh_recommendations(session: DBSessionDep):
     await session.execute(text("SELECT refresh_recommendable_editions_function()"))
     logger.info("Refreshed recommendable_editions materialized view")
     return {"msg": "ok"}
+
+
+@router.post("/maintenance/lapse-expired-schools")
+async def handle_lapse_expired_schools(session: DBSessionDep):
+    """Deactivate schools whose paid access came from an expired contribution grant.
+
+    A "contribute a month" payment to a school with no auto-renewing Stripe
+    subscription grants bounded paid access via a comped Subscription. Unlike a
+    Stripe subscription, that grant does not auto-lapse, so this sweep sets such
+    schools INACTIVE once the grant has expired.
+
+    Schools with an active auto-renewing Stripe subscription are never lapsed here
+    (Stripe drives their lifecycle). Intended to run on a Cloud Scheduler job
+    (OIDC auth via the background-tasks service account); the scheduler is wired
+    separately in the infrastructure repo.
+    """
+    now = datetime.utcnow()
+    expired_grants = (
+        (
+            await session.execute(
+                select(Subscription).where(
+                    Subscription.info["source"].astext == CONTRIBUTION_GRANT_SOURCE,
+                    Subscription.is_active.is_(True),
+                    Subscription.expiration < now,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    lapsed = 0
+    for grant in expired_grants:
+        # The grant itself has expired regardless of what happens to the school.
+        grant.is_active = False
+
+        # If the school now has an active auto-renewing Stripe subscription, leave
+        # it active — Stripe drives that lifecycle.
+        has_stripe_sub = (
+            await session.execute(
+                select(Subscription.id)
+                .where(
+                    Subscription.school_id == grant.school_id,
+                    Subscription.is_active.is_(True),
+                    Subscription.stripe_customer_id != "",
+                )
+                .limit(1)
+            )
+        ).first()
+        if has_stripe_sub is not None:
+            continue
+
+        school = (
+            await session.execute(
+                select(School).where(School.wriveted_identifier == grant.school_id)
+            )
+        ).scalar_one_or_none()
+        if school is not None and school.state == SchoolState.ACTIVE:
+            school.state = SchoolState.INACTIVE
+            lapsed += 1
+            logger.info(
+                "Lapsed school after contribution grant expired",
+                school=school.name,
+                grant_id=grant.id,
+            )
+
+    # get_async_session does not commit on teardown; persist the sweep.
+    await session.commit()
+    logger.info(
+        "Lapse sweep complete", lapsed=lapsed, grants_expired=len(expired_grants)
+    )
+    return {"msg": "ok", "lapsed": lapsed, "grants_expired": len(expired_grants)}

--- a/app/api/schools.py
+++ b/app/api/schools.py
@@ -41,6 +41,7 @@ from app.services.experiments import get_experiments
 from app.services.school_billing import (
     SchoolBillingError,
     create_school_checkout_session,
+    create_school_contribution_checkout_session,
 )
 from app.services.school_emails import render_school_staff_invite_html
 from app.utils.dict_utils import deep_merge_dicts
@@ -314,6 +315,37 @@ async def create_school_checkout(
     """
     try:
         checkout_url = await create_school_checkout_session(school, price_id=price_id)
+    except SchoolBillingError as e:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(e))
+    return SchoolCheckoutResponse(checkout_url=checkout_url)
+
+
+@router.post(
+    "/school/{wriveted_identifier}/contribute", response_model=SchoolCheckoutResponse
+)
+async def create_school_contribution(
+    price_id: Optional[str] = Query(
+        None,
+        description="One of the configured contribution price ids; defaults to the first.",
+    ),
+    school: School = Depends(aget_school_from_wriveted_id),
+    account: Union[User, ServiceAccount] = Depends(
+        get_current_active_user_or_service_account
+    ),
+):
+    """Start a one-off Stripe Checkout to contribute toward a school.
+
+    Payer-agnostic: any authenticated active user (or service account) may
+    contribute — a parent, public supporter, or library — not just the school
+    admin, so the returned URL can be shared. The contribution is scoped to the
+    school; when payment completes the Stripe webhook either credits the school's
+    existing subscription or, if the school has none, activates it as a paid
+    grant.
+    """
+    try:
+        checkout_url = await create_school_contribution_checkout_session(
+            school, price_id=price_id
+        )
     except SchoolBillingError as e:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(e))
     return SchoolCheckoutResponse(checkout_url=checkout_url)

--- a/app/config.py
+++ b/app/config.py
@@ -274,10 +274,23 @@ class Settings(BaseSettings):
     STRIPE_WEBHOOK_SECRET: str = ""
     # Stripe price ids offerable for a school subscription (first is the default).
     STRIPE_SCHOOL_PRICE_IDS: List[str] = []
+    # One-off Stripe price ids for a "contribute a month" payment toward a
+    # school's subscription (first is the default).
+    STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS: List[str] = []
+    # Notional monthly rate (in minor units, e.g. cents) used to convert a
+    # pay-what-you-want contribution into a proportional access grant for a school
+    # with no auto-renewing Stripe subscription: grant_days = round(amount /
+    # this * 30). Contributions stack (extend the expiry).
+    SCHOOL_CONTRIBUTION_MONTHLY_CENTS: int = 2500
     # Recipients for internal signup alerts (set per deployment). Empty disables.
     STAFF_ALERT_EMAILS: List[str] = []
 
-    @field_validator("STRIPE_SCHOOL_PRICE_IDS", "STAFF_ALERT_EMAILS", mode="before")
+    @field_validator(
+        "STRIPE_SCHOOL_PRICE_IDS",
+        "STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS",
+        "STAFF_ALERT_EMAILS",
+        mode="before",
+    )
     @classmethod
     def _split_csv_list(cls, v: Union[str, List[str]]) -> Union[str, List[str]]:
         # Accept a comma-separated env string as well as a JSON list.

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -45,6 +45,7 @@ from .school import School, SchoolState
 from .school_admin import SchoolAdmin
 from .series import Series
 from .service_account import ServiceAccount, ServiceAccountType
+from .stripe_contribution import StripeContributionReceipt
 from .student import Student
 from .subscription import Subscription
 from .supporter import Supporter

--- a/app/models/school.py
+++ b/app/models/school.py
@@ -145,11 +145,16 @@ class School(Base):
         back_populates="schools",
     )
 
+    # A school can transiently have more than one subscription row (e.g. a comped
+    # contribution grant that is retired when the school converts to a paying
+    # Stripe subscription). uselist=False must therefore resolve deterministically
+    # to the "live" one: active first, then latest expiry.
     subscription: Mapped[Optional["Subscription"]] = relationship(
         "Subscription",
         back_populates="school",
         uselist=False,
         cascade="all, delete-orphan",
+        order_by="(Subscription.is_active.desc(), Subscription.expiration.desc())",
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/app/models/stripe_contribution.py
+++ b/app/models/stripe_contribution.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class StripeContributionReceipt(Base):
+    """Idempotency + audit record for a processed one-off school contribution.
+
+    The Stripe checkout session id is the primary key; the webhook claims it with
+    an INSERT ... ON CONFLICT DO NOTHING before doing any work, so concurrent
+    webhook redeliveries cannot double-activate a school or double-send emails
+    (the money is separately protected by a Stripe idempotency key).
+    """
+
+    __tablename__ = "stripe_contribution_receipts"  # type: ignore[assignment]
+
+    checkout_session_id: Mapped[str] = mapped_column(String, primary_key=True)
+
+    school_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
+    amount_total: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    currency: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    # One of: balance_credit, school_activated, grant_extended, credit_failed.
+    crediting: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.current_timestamp(), nullable=False
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<StripeContributionReceipt {self.checkout_session_id} ({self.crediting})>"
+        )

--- a/app/repositories/school_repository.py
+++ b/app/repositories/school_repository.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Optional, Sequence
 
 from fastapi import HTTPException
-from sqlalchemy import delete, select, text, update
+from sqlalchemy import delete, exists, select, text, update
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session, selectinload
@@ -302,8 +302,18 @@ class SchoolRepositoryImpl(SchoolRepository):
                 Collection.book_count > 0
             )
         if has_active_subscription is not None:
-            school_query = school_query.join(Subscription).where(
-                Subscription.is_active == has_active_subscription
+            # "has active subscription" means paying: an active subscription
+            # backed by a real Stripe customer. Comped contribution grants
+            # (empty stripe_customer_id) are excluded. An EXISTS subquery (not a
+            # join) avoids duplicate School rows when a school has more than one
+            # subscription row.
+            paying_subscription = exists().where(
+                Subscription.school_id == School.wriveted_identifier,
+                Subscription.is_active.is_(True),
+                Subscription.stripe_customer_id != "",
+            )
+            school_query = school_query.where(
+                paying_subscription if has_active_subscription else ~paying_subscription
             )
         if official_identifier is not None:
             school_query = school_query.where(

--- a/app/services/school_billing.py
+++ b/app/services/school_billing.py
@@ -76,3 +76,67 @@ async def create_school_checkout_session(
         checkout_session_id=session.id,
     )
     return session.url
+
+
+async def create_school_contribution_checkout_session(
+    school: School, price_id: str | None = None
+) -> str:
+    """Create a one-off "contribute a month" Checkout Session and return its URL.
+
+    Unlike ``create_school_checkout_session`` this is a one-off payment
+    (``mode="payment"``), not a subscription. It is scoped to the school via
+    ``client_reference_id`` so the URL can be shared with any supporter (parent,
+    public sponsor, library) — the contribution funds that school regardless of
+    who pays. ``metadata["kind"]`` marks it as a contribution so the webhook can
+    distinguish it from a subscription checkout.
+
+    ``price_id`` selects one of the configured contribution prices; it must be
+    one of ``STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS`` (defaults to the first).
+    """
+    if not settings.STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS:
+        raise SchoolBillingError(
+            "STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS is not configured"
+        )
+    if not settings.STRIPE_SECRET_KEY:
+        raise SchoolBillingError("STRIPE_SECRET_KEY is not configured")
+
+    if price_id is None:
+        price_id = settings.STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS[0]
+    elif price_id not in settings.STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS:
+        raise SchoolBillingError(f"Unknown contribution price id: {price_id}")
+
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+    app_url = settings.HUEY_BOOKS_APP_URL.rstrip("/")
+    wriveted_id = str(school.wriveted_identifier)
+
+    params = {
+        "mode": "payment",
+        "line_items": [{"price": price_id, "quantity": 1}],
+        "client_reference_id": wriveted_id,
+        "success_url": f"{app_url}/school/contribute/success?session_id={{CHECKOUT_SESSION_ID}}",
+        "cancel_url": f"{app_url}/school/contribute/cancelled",
+        "metadata": {
+            "kind": "school_contribution",
+            "wriveted_school_id": wriveted_id,
+            "school_name": school.name,
+        },
+        "allow_promotion_codes": True,
+    }
+
+    try:
+        # The Stripe SDK is synchronous; offload so it doesn't block the loop.
+        session = await asyncio.to_thread(stripe.checkout.Session.create, **params)
+    except Exception as e:
+        logger.error(
+            "Failed to create school contribution checkout session",
+            wriveted_school_id=wriveted_id,
+            error=str(e),
+        )
+        raise SchoolBillingError(f"Could not create contribution checkout session: {e}")
+
+    logger.info(
+        "Created school contribution checkout session",
+        wriveted_school_id=wriveted_id,
+        checkout_session_id=session.id,
+    )
+    return session.url

--- a/app/services/school_emails.py
+++ b/app/services/school_emails.py
@@ -102,6 +102,97 @@ def render_school_renewal_reminder_html(
     )
 
 
+def _contribution_outcome_sentence(
+    outcome: str, school_name: str, access_until: Optional[str], *, third_person: bool
+) -> str:
+    """Accurate outcome copy shared by the payer and school contribution emails.
+
+    ``outcome`` is one of ``credited``, ``activated``, ``extended``, or
+    ``received`` (a fallback when the contribution could not be applied
+    automatically and needs manual handling).
+    """
+    school = escape(school_name)
+    when = f" through {escape(access_until)}" if access_until else ""
+    subject = "your school" if third_person else school
+    if outcome == "credited":
+        return (
+            f"<p>Your contribution has been credited toward {school}'s next Huey "
+            "Books invoice.</p>"
+            if not third_person
+            else "<p>Their contribution has been credited toward your school's "
+            "next Huey Books invoice.</p>"
+        )
+    if outcome == "activated":
+        return (
+            f"<p>Their contribution has activated {subject}{when}.</p>"
+            if third_person
+            else (
+                f"<p>Thanks to you, {school} is now live on Huey Books{when} and its "
+                "students can start reading.</p>"
+            )
+        )
+    if outcome == "extended":
+        return (
+            f"<p>Their contribution has extended {subject}'s access{when}.</p>"
+            if third_person
+            else f"<p>Your contribution has extended {school}'s access{when}.</p>"
+        )
+    # received: paid but not yet applied automatically
+    return (
+        "<p>Their contribution has been received; our team will apply it to your "
+        "school shortly.</p>"
+        if third_person
+        else f"<p>Your contribution toward {school} has been received; our team "
+        "will apply it shortly.</p>"
+    )
+
+
+def render_contribution_thankyou_html(
+    school_name: str,
+    amount: Optional[str],
+    outcome: str,
+    access_until: Optional[str] = None,
+) -> str:
+    """Sent to a supporter who paid a one-off contribution toward a school."""
+    gift = f" of {escape(amount)}" if amount else ""
+    outcome_html = _contribution_outcome_sentence(
+        outcome, school_name, access_until, third_person=False
+    )
+    return _shell(
+        "<h2>Thank you for contributing \U0001f49b</h2>"
+        "<p>Hi there,</p>"
+        f"<p>Thank you for your contribution{gift} toward "
+        f"{escape(school_name)}'s Huey Books subscription.</p>"
+        f"{outcome_html}"
+        "<p>This email is your receipt. If you have any questions just reply to "
+        "it.</p>"
+        "<p>Happy reading,<br>The Huey Books team</p>"
+    )
+
+
+def render_school_contribution_notice_html(
+    school_name: str,
+    contact_name: Optional[str],
+    amount: Optional[str],
+    outcome: str,
+    access_until: Optional[str] = None,
+) -> str:
+    """Sent to a school's contact when a supporter contributes toward them."""
+    greeting = f"Hi {escape(contact_name)}," if contact_name else "Hi there,"
+    gift = f" of {escape(amount)}" if amount else ""
+    outcome_html = _contribution_outcome_sentence(
+        outcome, school_name, access_until, third_person=True
+    )
+    return _shell(
+        "<h2>Someone contributed to your Huey Books subscription</h2>"
+        f"<p>{greeting}</p>"
+        f"<p>A supporter has contributed{gift} toward {escape(school_name)}'s "
+        "Huey Books subscription.</p>"
+        f"{outcome_html}"
+        "<p>Happy reading,<br>The Huey Books team</p>"
+    )
+
+
 def render_staff_new_school_alert_html(
     *,
     school_name: str,

--- a/app/services/stripe_events.py
+++ b/app/services/stripe_events.py
@@ -845,14 +845,8 @@ def _apply_or_extend_contribution_grant(
     )
     session.flush()
 
-    # Lock the grant row so concurrent contribution webhooks for the same school
-    # serialise: without this, two tasks can read the same expiration, each add
-    # its own days from that base, and the last commit clobbers the other —
-    # silently dropping a donor's paid extension (both receipts commit, so no
-    # retry). FOR UPDATE makes the second task read the first's committed expiry
-    # and stack onto it. (A concurrent first insert can't be locked here, but the
-    # PK conflict rolls back the whole transaction incl. the receipt claim, so
-    # Cloud Tasks retries into this extend path.)
+    # FOR UPDATE so concurrent contributions for the same school stack instead of
+    # clobbering each other's expiry.
     grant = session.execute(
         select(Subscription).where(Subscription.id == grant_id).with_for_update()
     ).scalar_one_or_none()

--- a/app/services/stripe_events.py
+++ b/app/services/stripe_events.py
@@ -845,7 +845,17 @@ def _apply_or_extend_contribution_grant(
     )
     session.flush()
 
-    grant = subscription_repository.get_by_id(session, subscription_id=grant_id)
+    # Lock the grant row so concurrent contribution webhooks for the same school
+    # serialise: without this, two tasks can read the same expiration, each add
+    # its own days from that base, and the last commit clobbers the other —
+    # silently dropping a donor's paid extension (both receipts commit, so no
+    # retry). FOR UPDATE makes the second task read the first's committed expiry
+    # and stack onto it. (A concurrent first insert can't be locked here, but the
+    # PK conflict rolls back the whole transaction incl. the receipt claim, so
+    # Cloud Tasks retries into this extend path.)
+    grant = session.execute(
+        select(Subscription).where(Subscription.id == grant_id).with_for_update()
+    ).scalar_one_or_none()
     if grant is None:
         expiration = now + timedelta(days=grant_days)
         grant = Subscription(

--- a/app/services/stripe_events.py
+++ b/app/services/stripe_events.py
@@ -1,6 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
+import stripe
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from stripe import Customer as StripeCustomer
 from stripe import Price as StripePrice
 from stripe import Product as StripeProduct
@@ -15,6 +18,7 @@ from app.models import School, User
 from app.models.event import EventSlackChannel
 from app.models.product import Product
 from app.models.school import SchoolState
+from app.models.stripe_contribution import StripeContributionReceipt
 from app.models.subscription import Subscription, SubscriptionType
 from app.models.user import UserAccountType
 from app.repositories.product_repository import product_repository
@@ -25,12 +29,28 @@ from app.schemas.subscription import SubscriptionCreateIn
 from app.services.email_notification import EmailType, send_email_reliable_sync
 from app.services.events import create_event
 from app.services.school_emails import (
+    render_contribution_thankyou_html,
     render_school_activated_html,
+    render_school_contribution_notice_html,
     render_school_renewal_reminder_html,
 )
 
 logger = get_logger()
 settings = get_settings()
+
+# Metadata marker set on a contribution Checkout Session (see school_billing);
+# the webhook routes strictly on this, not on checkout mode.
+CONTRIBUTION_METADATA_KIND = "school_contribution"
+# Title of the audit event recorded per processed contribution.
+CONTRIBUTION_EVENT_TITLE = "School contribution received"
+# Marks a Subscription as a comped grant funded by a one-off contribution (no
+# auto-renewing Stripe subscription behind it), distinguishable from a real
+# Stripe subscription.
+CONTRIBUTION_GRANT_SOURCE = "contribution_grant"
+# Synthetic Product + Subscription id prefix for contribution grants.
+CONTRIBUTION_GRANT_PRODUCT_ID = "comp_school_contribution"
+CONTRIBUTION_GRANT_PRODUCT_NAME = "School contribution (comped)"
+CONTRIBUTION_GRANT_SUBSCRIPTION_PREFIX = "comp_contribution_"
 
 
 def process_stripe_event(event_type: str, event_data):
@@ -88,6 +108,21 @@ def process_stripe_event(event_type: str, event_data):
 
     Session = get_session_maker()
     with Session() as session:
+        # One-off "contribute a month" checkouts run in payment mode and may have
+        # no Stripe customer (guest checkout), so resolve the school directly and
+        # bypass the customer-centric extraction the subscription events rely on.
+        if event_type in (
+            "checkout.session.completed",
+            "checkout.session.async_payment_succeeded",
+        ) and _is_contribution_checkout(event_data):
+            contribution_school = _resolve_school_from_client_reference(
+                session, event_data
+            )
+            _handle_contribution_checkout_completed(
+                session, contribution_school, event_data
+            )
+            return
+
         wriveted_user, school, stripe_customer = (
             _extract_user_and_customer_from_stripe_object(
                 session, event_data, object_type
@@ -388,6 +423,9 @@ def _handle_checkout_session_completed(
     if school is not None:
         if paid:
             _activate_school_after_payment(session, school, stripe_customer_email)
+            # A paying Stripe subscription supersedes any comped contribution
+            # grant, so retire it to keep a single active subscription row.
+            _retire_contribution_grants(session, school.wriveted_identifier)
         else:
             logger.warning(
                 "School checkout completed without cleared payment; leaving inactive",
@@ -499,6 +537,451 @@ def _activate_school_after_payment(session, school: School, customer_email):
     )
 
 
+def _is_contribution_checkout(event_data: dict) -> bool:
+    """Whether a completed checkout session is a one-off school contribution.
+
+    Distinguished strictly by our own metadata marker, not by ``mode`` — a bare
+    ``mode == "payment"`` check would swallow any future one-off checkout.
+    """
+    metadata = event_data.get("metadata") or {}
+    return metadata.get("kind") == CONTRIBUTION_METADATA_KIND
+
+
+def _resolve_school_from_client_reference(
+    session, event_data: dict
+) -> Optional[School]:
+    """Resolve the school a contribution is scoped to from client_reference_id."""
+    client_reference_id = event_data.get("client_reference_id")
+    if client_reference_id in (None, "undefined", "null"):
+        return None
+    return school_repository.get_by_wriveted_id(
+        session, wriveted_id=client_reference_id
+    )
+
+
+def _format_money(amount_total: Optional[int], currency: str) -> Optional[str]:
+    """Format a Stripe minor-unit amount with its ISO currency code (no symbol)."""
+    if amount_total is None:
+        return None
+    return f"{amount_total / 100:.2f} {currency.upper()}"
+
+
+def _get_active_stripe_subscription(session, school: School) -> Optional[Subscription]:
+    """Return the school's active auto-renewing Stripe subscription, if any.
+
+    Queried directly rather than via ``school.subscription`` (a one-to-one
+    relationship that is ambiguous if a school ever has both a comped grant row
+    and a Stripe subscription row). Comped grants carry an empty
+    ``stripe_customer_id``, so the ``!= ""`` filter excludes them.
+    """
+    return (
+        session.execute(
+            select(Subscription)
+            .where(
+                Subscription.school_id == school.wriveted_identifier,
+                Subscription.is_active.is_(True),
+                Subscription.stripe_customer_id != "",
+            )
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
+
+
+def _get_active_contribution_grant(session, school_id) -> Optional[Subscription]:
+    """Return a school's active, unexpired comped contribution grant, if any."""
+    now = datetime.utcnow()
+    return (
+        session.execute(
+            select(Subscription)
+            .where(
+                Subscription.school_id == school_id,
+                Subscription.is_active.is_(True),
+                Subscription.info["source"].astext == CONTRIBUTION_GRANT_SOURCE,
+                Subscription.expiration > now,
+            )
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
+
+
+def _retire_contribution_grants(session, school_id) -> None:
+    """Deactivate a school's comped contribution grant(s).
+
+    Called when a school gains/uses a real auto-renewing Stripe subscription, so
+    the (superseded) grant does not leave a second active ``subscriptions`` row —
+    which would make ``School.subscription`` (uselist=False) non-deterministic and
+    the "supporter"/"paying" flags unreliable.
+    """
+    grants = (
+        session.execute(
+            select(Subscription).where(
+                Subscription.school_id == school_id,
+                Subscription.is_active.is_(True),
+                Subscription.info["source"].astext == CONTRIBUTION_GRANT_SOURCE,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for grant in grants:
+        grant.is_active = False
+        logger.info(
+            "Retired contribution grant superseded by Stripe subscription",
+            grant_id=grant.id,
+        )
+
+
+def _claim_contribution_session(session, checkout_session_id: str) -> bool:
+    """Claim a checkout session id for processing; return True if we won the claim.
+
+    Race-safe against Stripe webhook redelivery: the insert-on-conflict serialises
+    concurrent deliveries on the session-id primary key, so only the first caller
+    proceeds to activate the school / send emails.
+    """
+    result = session.execute(
+        pg_insert(StripeContributionReceipt)
+        .values(checkout_session_id=checkout_session_id)
+        .on_conflict_do_nothing(index_elements=["checkout_session_id"])
+    )
+    return result.rowcount == 1
+
+
+def _handle_contribution_checkout_completed(
+    session, school: Optional[School], event_data: dict
+) -> None:
+    """Apply a completed one-off contribution toward a school's subscription.
+
+    Contributions are pay-what-you-want (``amount_total`` varies per checkout).
+
+    Crediting model:
+    - **Active Stripe subscription** (auto-renewing): apply ``amount_total`` as a
+      Stripe customer-balance credit on that subscription's customer, reducing the
+      next renewal invoice.
+    - **No active Stripe subscription**: the contribution buys a bounded paid
+      grant whose length is proportional to the amount paid (see
+      ``_contribution_grant_days``). A first-class comped Subscription is created
+      (or, if one already exists, its expiry is extended by the newly-computed days
+      — contributions stack), and the school is activated. The grant has no Stripe
+      subscription behind it, so it does not auto-renew; it is lapsed to INACTIVE
+      after expiry by the ``/maintenance/lapse-expired-schools`` sweep.
+
+    Gated on payment_status == "paid" and idempotent on the checkout session id
+    (Stripe redelivers webhook events).
+    """
+    payment_status = event_data.get("payment_status")
+    if payment_status != "paid":
+        logger.warning(
+            "Contribution checkout completed without cleared payment; ignoring",
+            payment_status=payment_status,
+        )
+        return
+
+    checkout_session_id = event_data.get("id")
+    if not checkout_session_id:
+        logger.warning("Contribution checkout completed without an id; ignoring")
+        return
+
+    if school is None:
+        logger.warning(
+            "Contribution checkout could not be matched to a school; ignoring",
+            checkout_session_id=checkout_session_id,
+        )
+        return
+
+    if not _claim_contribution_session(session, checkout_session_id):
+        logger.info(
+            "Ignoring duplicate contribution event",
+            checkout_session_id=checkout_session_id,
+        )
+        return
+
+    amount_total = event_data.get("amount_total")
+    currency = (event_data.get("currency") or "aud").lower()
+    payer_email = (event_data.get("customer_details") or {}).get(
+        "email"
+    ) or event_data.get("customer_email")
+    amount_str = _format_money(amount_total, currency)
+
+    active_stripe_subscription = _get_active_stripe_subscription(session, school)
+
+    access_until: Optional[str] = None
+    stripe_customer_id: Optional[str] = None
+    if active_stripe_subscription is not None:
+        stripe_customer_id = active_stripe_subscription.stripe_customer_id
+        # A transient credit failure re-raises here (rolling back the claim); a
+        # permanent one returns False.
+        credited = _apply_customer_balance_credit(
+            stripe_customer_id=stripe_customer_id,
+            amount_total=amount_total,
+            currency=currency,
+            school_name=school.name,
+            checkout_session_id=checkout_session_id,
+        )
+        # The live Stripe subscription supersedes any leftover comp grant row.
+        _retire_contribution_grants(session, school.wriveted_identifier)
+        outcome = "credited" if credited else "received"
+        crediting = "balance_credit" if credited else "credit_failed"
+    else:
+        outcome, expiration = _apply_or_extend_contribution_grant(
+            session, school, amount_total
+        )
+        access_until = expiration.date().isoformat()
+        crediting = "grant_extended" if outcome == "extended" else "school_activated"
+
+    _record_contribution_receipt(
+        session,
+        checkout_session_id=checkout_session_id,
+        school=school,
+        amount_total=amount_total,
+        currency=currency,
+        crediting=crediting,
+    )
+
+    if payer_email:
+        send_email_reliable_sync(
+            db=session,
+            email_data={
+                "from_email": settings.BROADCAST_FROM_EMAIL,
+                "from_name": "Huey Books",
+                "to_emails": [payer_email],
+                "subject": f"Thank you for contributing to {school.name}",
+                "html_content": render_contribution_thankyou_html(
+                    school.name, amount_str, outcome, access_until
+                ),
+            },
+            email_type=EmailType.TRANSACTIONAL,
+        )
+
+    onboarding = (school.info or {}).get("onboarding") or {}
+    school_contact_email = onboarding.get("contact_email")
+    if school_contact_email and school_contact_email != payer_email:
+        send_email_reliable_sync(
+            db=session,
+            email_data={
+                "from_email": settings.BROADCAST_FROM_EMAIL,
+                "from_name": "Huey Books",
+                "to_emails": [school_contact_email],
+                "subject": f"A supporter contributed to {school.name} on Huey Books",
+                "html_content": render_school_contribution_notice_html(
+                    school.name,
+                    onboarding.get("contact_name"),
+                    amount_str,
+                    outcome,
+                    access_until,
+                ),
+            },
+            email_type=EmailType.TRANSACTIONAL,
+        )
+
+    create_event(
+        session=session,
+        title=CONTRIBUTION_EVENT_TITLE,
+        description=f"Contribution received toward {school.name}",
+        info={
+            "checkout_session_id": checkout_session_id,
+            "amount_total": amount_total,
+            "currency": currency,
+            "crediting": crediting,
+            "outcome": outcome,
+            "payer_email": payer_email,
+            "access_until": access_until,
+            "stripe_customer_id": stripe_customer_id,
+        },
+        school=school,
+        slack_channel=(
+            None if "test" in checkout_session_id else EventSlackChannel.MEMBERSHIPS
+        ),
+        slack_extra={"school_name": school.name, "amount": amount_str or ""},
+        enable_processing=True,
+        external_notifications=True,
+    )
+    logger.info(
+        "Processed school contribution",
+        school=school.name,
+        crediting=crediting,
+        outcome=outcome,
+        amount=amount_str,
+        checkout_session_id=checkout_session_id,
+    )
+
+
+def _contribution_grant_days(amount_total: Optional[int]) -> int:
+    """Days of access a pay-what-you-want contribution buys.
+
+    Proportional to the amount paid against a configured monthly rate:
+    ``round(amount / SCHOOL_CONTRIBUTION_MONTHLY_CENTS * 30)``, floored at 1 day
+    so any accepted payment grants at least a day.
+    """
+    monthly_cents = settings.SCHOOL_CONTRIBUTION_MONTHLY_CENTS
+    if not amount_total or monthly_cents <= 0:
+        return 1
+    # Clamp to [1, 10 years] so an absurd amount can't overflow the expiry
+    # datetime and wedge the webhook in a retry loop.
+    return max(1, min(round(amount_total / monthly_cents * 30), 3650))
+
+
+def _apply_or_extend_contribution_grant(
+    session, school: School, amount_total: Optional[int]
+) -> tuple[str, datetime]:
+    """Create or extend a school's comped contribution grant and activate it.
+
+    Returns ``(outcome, expiration)`` where outcome is ``"activated"`` (a new or
+    lapsed grant) or ``"extended"`` (an already-live grant whose expiry moved
+    out). The granted period is proportional to the (pay-what-you-want) amount
+    paid. Contributions stack: an unexpired grant extends by the newly-computed
+    days from its current expiry, an expired/absent one from now.
+    """
+    now = datetime.utcnow()
+    grant_days = _contribution_grant_days(amount_total)
+    grant_id = f"{CONTRIBUTION_GRANT_SUBSCRIPTION_PREFIX}{school.wriveted_identifier}"
+
+    # Ensure the synthetic comp product exists (FK target for the grant).
+    session.merge(
+        Product(id=CONTRIBUTION_GRANT_PRODUCT_ID, name=CONTRIBUTION_GRANT_PRODUCT_NAME)
+    )
+    session.flush()
+
+    grant = subscription_repository.get_by_id(session, subscription_id=grant_id)
+    if grant is None:
+        expiration = now + timedelta(days=grant_days)
+        grant = Subscription(
+            id=grant_id,
+            school_id=school.wriveted_identifier,
+            type=SubscriptionType.SCHOOL,
+            stripe_customer_id="",
+            is_active=True,
+            expiration=expiration,
+            product_id=CONTRIBUTION_GRANT_PRODUCT_ID,
+            info={"source": CONTRIBUTION_GRANT_SOURCE},
+        )
+        session.add(grant)
+        outcome = "activated"
+    else:
+        live = grant.is_active and grant.expiration and grant.expiration > now
+        base = grant.expiration if live else now
+        expiration = base + timedelta(days=grant_days)
+        grant.is_active = True
+        grant.expiration = expiration
+        outcome = (
+            "extended" if (live and school.state == SchoolState.ACTIVE) else "activated"
+        )
+
+    if school.state != SchoolState.ACTIVE:
+        school.state = SchoolState.ACTIVE
+        session.add(school)
+
+    logger.info(
+        "Applied contribution grant",
+        school=school.name,
+        grant_id=grant_id,
+        outcome=outcome,
+        expiration=str(expiration),
+    )
+    return outcome, expiration
+
+
+def _record_contribution_receipt(
+    session,
+    *,
+    checkout_session_id: str,
+    school: School,
+    amount_total: Optional[int],
+    currency: str,
+    crediting: str,
+) -> None:
+    """Fill in the details on the idempotency receipt claimed earlier."""
+    receipt = session.get(StripeContributionReceipt, checkout_session_id)
+    if receipt is not None:
+        receipt.school_id = school.wriveted_identifier
+        receipt.amount_total = amount_total
+        receipt.currency = currency
+        receipt.crediting = crediting
+
+
+def _apply_customer_balance_credit(
+    *,
+    stripe_customer_id: str,
+    amount_total: Optional[int],
+    currency: str,
+    school_name: str,
+    checkout_session_id: str,
+) -> bool:
+    """Credit the contribution to the school's Stripe customer balance.
+
+    A negative balance transaction reduces the customer's next renewal invoice.
+    Returns True on success, False on a **permanent** failure (fail soft: the
+    contribution can't be auto-credited and is recorded ``credit_failed`` for
+    manual handling — e.g. a currency mismatch). A **potentially transient** Stripe
+    error (rate limit, connection, API error) is **re-raised** so the caller
+    aborts before committing the idempotency claim and Cloud Tasks retries; the
+    ``idempotency_key`` makes that retry safe from double-crediting.
+    """
+    if not amount_total:
+        logger.warning(
+            "Contribution has no amount to credit; skipping balance credit",
+            checkout_session_id=checkout_session_id,
+        )
+        return False
+
+    # Retrieving the customer can fail transiently; let that re-raise to retry.
+    customer = StripeCustomer.retrieve(stripe_customer_id)
+    customer_currency = (customer.get("currency") or "").lower()
+    if customer_currency and customer_currency != currency:
+        # Permanent: a balance transaction must match the customer's currency.
+        logger.error(
+            "Contribution currency does not match customer balance currency; "
+            "skipping balance credit for manual handling",
+            stripe_customer_id=stripe_customer_id,
+            contribution_currency=currency,
+            customer_currency=customer_currency,
+            checkout_session_id=checkout_session_id,
+        )
+        return False
+
+    try:
+        StripeCustomer.create_balance_transaction(
+            stripe_customer_id,
+            amount=-amount_total,
+            currency=currency,
+            description=(
+                f"Contribution toward {school_name} (checkout {checkout_session_id})"
+            ),
+            idempotency_key=f"contribution-{checkout_session_id}",
+        )
+    except stripe.error.InvalidRequestError as e:
+        # Permanent client error (bad params, e.g. currency mismatch that slipped
+        # past the check): retrying won't help, so fail soft for manual handling.
+        logger.error(
+            "Permanent Stripe error applying contribution credit; recording as failed",
+            stripe_customer_id=stripe_customer_id,
+            checkout_session_id=checkout_session_id,
+            error=str(e),
+        )
+        return False
+    except Exception as e:
+        # Potentially transient (rate limit, connection, API error, or unexpected):
+        # re-raise so the claim is not committed and the task retries.
+        logger.warning(
+            "Transient error applying contribution credit; re-raising to retry",
+            stripe_customer_id=stripe_customer_id,
+            checkout_session_id=checkout_session_id,
+            error=str(e),
+        )
+        raise
+
+    logger.info(
+        "Applied contribution as customer balance credit",
+        stripe_customer_id=stripe_customer_id,
+        amount=amount_total,
+        currency=currency,
+    )
+    return True
+
+
 def _handle_invoice_upcoming(session, event_data):
     """Remind an active school's contact that their subscription renews soon."""
     stripe_subscription_id = event_data.get("subscription")
@@ -599,6 +1082,15 @@ def _handle_subscription_created(
     )
     if created:
         logger.info("Created a new subscription", subscription=subscription)
+
+    # A real, active Stripe subscription for a school supersedes any comped
+    # contribution grant; retire it so there is a single active subscription row.
+    if (
+        school is not None
+        and subscription.is_active
+        and subscription.stripe_customer_id
+    ):
+        _retire_contribution_grants(session, school.wriveted_identifier)
 
 
 def _handle_subscription_updated(
@@ -705,11 +1197,24 @@ def _handle_subscription_cancelled(
                 session, str(subscription.school_id)
             )
         if school is not None and school.state == SchoolState.ACTIVE:
-            school.state = SchoolState.INACTIVE
-            session.add(school)
-            logger.info(
-                "Deactivated school after subscription ended", school=school.name
+            # Don't deactivate a school that still has paid access via an
+            # unexpired comped contribution grant (the lapse sweep will retire it
+            # when it expires).
+            live_grant = _get_active_contribution_grant(
+                session, school.wriveted_identifier
             )
+            if live_grant is not None:
+                logger.info(
+                    "School retains access via active contribution grant; "
+                    "not deactivating after Stripe subscription ended",
+                    school=school.name,
+                )
+            else:
+                school.state = SchoolState.INACTIVE
+                session.add(school)
+                logger.info(
+                    "Deactivated school after subscription ended", school=school.name
+                )
 
         # Use unified event workflow instead of direct crud.event.create
         create_event(

--- a/app/tests/integration/test_school_contribution.py
+++ b/app/tests/integration/test_school_contribution.py
@@ -1,0 +1,577 @@
+"""Integration tests for the "contribute a month" flow via Stripe webhooks.
+
+Covers the crediting model:
+- a contribution to a school with an active *Stripe* subscription becomes a
+  customer-balance credit (currency-validated, fail-soft);
+- a contribution to a school with no such subscription buys a bounded comped
+  grant (creating or extending a Subscription and activating the school);
+- the lapse sweep deactivates schools whose grant has expired, but not schools
+  kept alive by a live Stripe subscription;
+- duplicate webhook deliveries are idempotent.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+import stripe
+from sqlalchemy import select, text
+
+from app.models.product import Product
+from app.models.school import School, SchoolState
+from app.models.stripe_contribution import StripeContributionReceipt
+from app.models.subscription import Subscription, SubscriptionType
+from app.repositories.school_repository import school_repository
+from app.repositories.subscription_repository import subscription_repository
+from app.services.stripe_events import (
+    CONTRIBUTION_GRANT_PRODUCT_ID,
+    CONTRIBUTION_GRANT_SOURCE,
+    CONTRIBUTION_GRANT_SUBSCRIPTION_PREFIX,
+    _handle_checkout_session_completed,
+    _handle_contribution_checkout_completed,
+    _handle_subscription_cancelled,
+    _is_contribution_checkout,
+)
+
+
+def _grant_id(school) -> str:
+    return f"{CONTRIBUTION_GRANT_SUBSCRIPTION_PREFIX}{school.wriveted_identifier}"
+
+
+def _email_count(session) -> int:
+    session.rollback()
+    return session.execute(
+        text("SELECT COUNT(*) FROM event_outbox WHERE event_type='email_notification'")
+    ).scalar()
+
+
+def _contribution_event(test_school, session_id="cs_contrib", amount_total=5000) -> dict:
+    return {
+        "id": session_id,
+        "object": "checkout.session",
+        "mode": "payment",
+        "metadata": {
+            "kind": "school_contribution",
+            "wriveted_school_id": str(test_school.wriveted_identifier),
+        },
+        "client_reference_id": str(test_school.wriveted_identifier),
+        "payment_status": "paid",
+        "amount_total": amount_total,
+        "currency": "aud",
+        "customer_details": {"email": "payer@example.com"},
+    }
+
+
+def _fresh_school(session, test_school):
+    """Re-fetch the school so its subscription relationship is loaded."""
+    return school_repository.get_by_wriveted_id(
+        session, wriveted_id=str(test_school.wriveted_identifier)
+    )
+
+
+def _give_active_stripe_subscription(session, test_school):
+    # merge (not add) so the shared Product row survives across tests without a
+    # primary-key collision (only the school is cleaned up between tests).
+    session.merge(Product(id="price_contrib_active", name="Supporter School"))
+    session.flush()
+    session.add(
+        Subscription(
+            id="sub_contrib_active",
+            product_id="price_contrib_active",
+            stripe_customer_id="cus_contrib_active",
+            school_id=test_school.wriveted_identifier,
+            type=SubscriptionType.SCHOOL,
+            is_active=True,
+            expiration=datetime(2099, 1, 1),
+        )
+    )
+    session.commit()
+
+
+def _make_pending(session, test_school):
+    test_school.state = SchoolState.PENDING
+    test_school.info = {
+        **(test_school.info or {}),
+        "onboarding": {
+            "contact_email": "contact@school.example",
+            "contact_name": "Sam",
+        },
+    }
+    session.add(test_school)
+    session.commit()
+
+
+# --- routing (M1: strictly by metadata kind, never bare mode) ---
+
+
+def test_routing_matches_only_on_metadata_kind():
+    assert _is_contribution_checkout({"mode": "payment", "metadata": {}}) is False
+    assert _is_contribution_checkout({"mode": "payment"}) is False
+    assert (
+        _is_contribution_checkout(
+            {"mode": "subscription", "metadata": {"kind": "school_contribution"}}
+        )
+        is True
+    )
+    assert _is_contribution_checkout({"metadata": {"kind": "other"}}) is False
+
+
+# --- bounded grant (no active Stripe subscription) ---
+
+
+@patch("app.services.stripe_events.StripeCustomer")
+def test_contribution_without_subscription_creates_proportional_grant(
+    mock_cust, session, test_school
+):
+    _make_pending(session, test_school)
+    school = _fresh_school(session, test_school)
+
+    # $50 at the default $25/mo notional rate -> ~60 days of access.
+    before = datetime.utcnow()
+    _handle_contribution_checkout_completed(
+        session, school, _contribution_event(test_school, "cs_grant", amount_total=5000)
+    )
+
+    mock_cust.create_balance_transaction.assert_not_called()
+    session.rollback()
+    session.refresh(test_school)
+    assert test_school.state == SchoolState.ACTIVE
+
+    grant = subscription_repository.get_by_id(session, _grant_id(test_school))
+    assert grant is not None
+    assert grant.is_active
+    assert (grant.info or {}).get("source") == CONTRIBUTION_GRANT_SOURCE
+    assert grant.stripe_customer_id == ""
+    granted_days = (grant.expiration - before).days
+    assert 59 <= granted_days <= 61
+
+
+@patch("app.services.stripe_events.StripeCustomer")
+def test_larger_contribution_grants_more_days(mock_cust, session, test_school):
+    _make_pending(session, test_school)
+    before = datetime.utcnow()
+
+    # $150 -> ~180 days, materially more than the $50 -> ~60 days case above.
+    _handle_contribution_checkout_completed(
+        session,
+        _fresh_school(session, test_school),
+        _contribution_event(test_school, "cs_big", amount_total=15000),
+    )
+    session.rollback()
+    grant = subscription_repository.get_by_id(session, _grant_id(test_school))
+    granted_days = (grant.expiration - before).days
+    assert 179 <= granted_days <= 181
+
+
+@patch("app.services.stripe_events.StripeCustomer")
+def test_repeat_contribution_extends_by_proportional_days(
+    mock_cust, session, test_school
+):
+    _make_pending(session, test_school)
+
+    _handle_contribution_checkout_completed(
+        session,
+        _fresh_school(session, test_school),
+        _contribution_event(test_school, "cs_g1", amount_total=5000),
+    )
+    session.rollback()
+    first_expiry = subscription_repository.get_by_id(
+        session, _grant_id(test_school)
+    ).expiration
+
+    # A second $50 contribution extends by ~60 more days from the first expiry.
+    _handle_contribution_checkout_completed(
+        session,
+        _fresh_school(session, test_school),
+        _contribution_event(test_school, "cs_g2", amount_total=5000),
+    )
+    session.rollback()
+    second_expiry = subscription_repository.get_by_id(
+        session, _grant_id(test_school)
+    ).expiration
+
+    extra_days = (second_expiry - first_expiry).days
+    assert 59 <= extra_days <= 61
+
+
+# --- active Stripe subscription -> customer balance credit ---
+
+
+@patch("app.services.stripe_events.StripeCustomer")
+def test_contribution_with_active_stripe_subscription_credits_balance(
+    mock_cust, session, test_school
+):
+    _give_active_stripe_subscription(session, test_school)
+    mock_cust.retrieve.return_value = {"currency": "aud"}
+    school = _fresh_school(session, test_school)
+
+    _handle_contribution_checkout_completed(
+        session, school, _contribution_event(test_school, "cs_credit")
+    )
+
+    mock_cust.create_balance_transaction.assert_called_once()
+    _, kwargs = mock_cust.create_balance_transaction.call_args
+    assert kwargs["amount"] == -5000
+    assert kwargs["currency"] == "aud"
+    assert kwargs["idempotency_key"] == "contribution-cs_credit"
+
+    session.rollback()
+    session.refresh(test_school)
+    assert test_school.state == SchoolState.ACTIVE  # unchanged
+    receipt = session.get(StripeContributionReceipt, "cs_credit")
+    assert receipt.crediting == "balance_credit"
+
+
+@patch("app.services.stripe_events.StripeCustomer")
+def test_contribution_currency_mismatch_soft_fails(mock_cust, session, test_school):
+    _give_active_stripe_subscription(session, test_school)
+    # Customer balance is in USD; the AUD contribution must not be force-credited.
+    mock_cust.retrieve.return_value = {"currency": "usd"}
+    school = _fresh_school(session, test_school)
+
+    # Must not raise (a raise would poison the webhook into infinite retries).
+    _handle_contribution_checkout_completed(
+        session, school, _contribution_event(test_school, "cs_mismatch")
+    )
+
+    mock_cust.create_balance_transaction.assert_not_called()
+    session.rollback()
+    receipt = session.get(StripeContributionReceipt, "cs_mismatch")
+    assert receipt.crediting == "credit_failed"
+
+
+@patch("app.services.stripe_events.StripeCustomer")
+def test_contribution_permanent_stripe_error_soft_fails(
+    mock_cust, session, test_school
+):
+    _give_active_stripe_subscription(session, test_school)
+    mock_cust.retrieve.return_value = {"currency": "aud"}
+    # InvalidRequestError is a permanent client error: retrying won't help.
+    mock_cust.create_balance_transaction.side_effect = stripe.error.InvalidRequestError(
+        "bad param", "amount"
+    )
+    school = _fresh_school(session, test_school)
+
+    # Must not raise; recorded as credit_failed for manual handling.
+    _handle_contribution_checkout_completed(
+        session, school, _contribution_event(test_school, "cs_perm")
+    )
+
+    session.rollback()
+    receipt = session.get(StripeContributionReceipt, "cs_perm")
+    assert receipt.crediting == "credit_failed"
+
+
+@patch("app.services.stripe_events.StripeCustomer")
+def test_contribution_transient_stripe_error_reraises(mock_cust, session, test_school):
+    _give_active_stripe_subscription(session, test_school)
+    mock_cust.retrieve.return_value = {"currency": "aud"}
+    # A connection error is potentially transient: re-raise so the task retries.
+    mock_cust.create_balance_transaction.side_effect = stripe.error.APIConnectionError(
+        "network blip"
+    )
+    school = _fresh_school(session, test_school)
+
+    with pytest.raises(stripe.error.APIConnectionError):
+        _handle_contribution_checkout_completed(
+            session, school, _contribution_event(test_school, "cs_transient")
+        )
+
+    # The idempotency claim was rolled back with the aborted transaction, so a
+    # retry can reprocess.
+    session.rollback()
+    assert session.get(StripeContributionReceipt, "cs_transient") is None
+
+
+# --- idempotency ---
+
+
+@patch("app.services.stripe_events.StripeCustomer")
+def test_duplicate_contribution_event_is_noop(mock_cust, session, test_school):
+    _make_pending(session, test_school)
+
+    _handle_contribution_checkout_completed(
+        session,
+        _fresh_school(session, test_school),
+        _contribution_event(test_school, "cs_dup"),
+    )
+    emails_after_first = _email_count(session)
+    first_expiry = subscription_repository.get_by_id(
+        session, _grant_id(test_school)
+    ).expiration
+
+    # Stripe redelivers the same event; already claimed -> full no-op.
+    _handle_contribution_checkout_completed(
+        session,
+        _fresh_school(session, test_school),
+        _contribution_event(test_school, "cs_dup"),
+    )
+    assert _email_count(session) == emails_after_first
+    # Not double-extended.
+    assert (
+        subscription_repository.get_by_id(session, _grant_id(test_school)).expiration
+        == first_expiry
+    )
+
+
+# --- grant -> Stripe subscription conversion ---
+
+
+def _mock_checkout_stripe(mock_sub, mock_cust, mock_price, mock_prod):
+    sub = MagicMock()
+    sub.customer = "cus_convert"
+    sub.current_period_end = 1893456000
+    sub.__getitem__.return_value = {"data": [{"price": {"id": "price_convert"}}]}
+    mock_sub.retrieve.return_value = sub
+
+    cust = Mock(spec=["get", "metadata", "name", "save"])
+    cust.get.return_value = "payer@example.com"
+    cust.metadata = {}
+    cust.name = "Payer"
+    cust.save.return_value = None
+    mock_cust.retrieve.return_value = cust
+
+    mock_price.retrieve.return_value = Mock(product="prod_convert")
+    product = Mock()
+    product.name = "Supporter School"
+    mock_prod.retrieve.return_value = product
+
+
+@patch("app.services.stripe_events.StripeProduct")
+@patch("app.services.stripe_events.StripePrice")
+@patch("app.services.stripe_events.StripeCustomer")
+@patch("app.services.stripe_events.StripeSubscription")
+def test_grant_to_stripe_subscription_conversion_retires_grant(
+    mock_sub, mock_cust, mock_price, mock_prod, session, test_school
+):
+    # 1. School gains a comped grant via a contribution (no Stripe calls here).
+    _make_pending(session, test_school)
+    _handle_contribution_checkout_completed(
+        session,
+        _fresh_school(session, test_school),
+        _contribution_event(test_school, "cs_pre", amount_total=5000),
+    )
+    session.rollback()
+    assert subscription_repository.get_by_id(session, _grant_id(test_school)).is_active
+
+    # 2. The school then converts to a paying Stripe subscription.
+    _mock_checkout_stripe(mock_sub, mock_cust, mock_price, mock_prod)
+    _handle_checkout_session_completed(
+        session,
+        None,
+        _fresh_school(session, test_school),
+        {
+            "id": "cs_convert",
+            "object": "checkout.session",
+            "subscription": "sub_convert",
+            "client_reference_id": str(test_school.wriveted_identifier),
+            "payment_status": "paid",
+        },
+    )
+    session.rollback()
+    session.expire_all()
+
+    # The grant row survives (not orphan-deleted) but is retired.
+    grant = subscription_repository.get_by_id(session, _grant_id(test_school))
+    assert grant is not None
+    assert grant.is_active is False
+
+    # Exactly one active subscription row remains — the paying Stripe one.
+    active = (
+        session.execute(
+            select(Subscription).where(
+                Subscription.school_id == test_school.wriveted_identifier,
+                Subscription.is_active.is_(True),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(active) == 1
+    assert active[0].stripe_customer_id != ""
+
+    # School.subscription (uselist=False) resolves to the live paying one.
+    school = _fresh_school(session, test_school)
+    assert school.subscription is not None
+    assert school.subscription.is_active
+    assert school.subscription.stripe_customer_id != ""
+
+    # The grant row is still queryable after a flush (delete-orphan didn't fire).
+    session.commit()
+    assert subscription_repository.get_by_id(session, _grant_id(test_school)) is not None
+
+
+# --- cancellation with a live comp grant ---
+
+
+def test_subscription_cancelled_keeps_school_active_with_live_grant(
+    session, test_school
+):
+    test_school.state = SchoolState.ACTIVE
+    session.add(test_school)
+    session.merge(Product(id="price_cancel_grant", name="Real"))
+    session.merge(Product(id=CONTRIBUTION_GRANT_PRODUCT_ID, name="comp"))
+    session.flush()
+    session.add(
+        Subscription(
+            id="sub_cancel_grant",
+            product_id="price_cancel_grant",
+            stripe_customer_id="cus_cg",
+            school_id=test_school.wriveted_identifier,
+            type=SubscriptionType.SCHOOL,
+            is_active=True,
+            expiration=datetime(2099, 1, 1),
+        )
+    )
+    session.add(
+        Subscription(
+            id=_grant_id(test_school),
+            product_id=CONTRIBUTION_GRANT_PRODUCT_ID,
+            stripe_customer_id="",
+            school_id=test_school.wriveted_identifier,
+            type=SubscriptionType.SCHOOL,
+            is_active=True,
+            expiration=datetime.utcnow() + timedelta(days=30),
+            info={"source": CONTRIBUTION_GRANT_SOURCE},
+        )
+    )
+    session.commit()
+
+    _handle_subscription_cancelled(
+        session,
+        None,
+        None,
+        {"id": "sub_cancel_grant", "object": "subscription", "ended_at": 1893456000},
+    )
+
+    session.rollback()
+    session.refresh(test_school)
+    # An unexpired comp grant keeps the school active despite the Stripe sub ending.
+    assert test_school.state == SchoolState.ACTIVE
+
+
+# --- has_active_subscription staff filter ---
+
+
+def test_has_active_subscription_filter_excludes_comps_and_dedupes(
+    session, test_school
+):
+    # test_school: a paying Stripe subscription AND a comp grant (two rows).
+    _give_active_stripe_subscription(session, test_school)
+    session.merge(Product(id=CONTRIBUTION_GRANT_PRODUCT_ID, name="comp"))
+    session.flush()
+    session.add(
+        Subscription(
+            id=_grant_id(test_school),
+            product_id=CONTRIBUTION_GRANT_PRODUCT_ID,
+            stripe_customer_id="",
+            school_id=test_school.wriveted_identifier,
+            type=SubscriptionType.SCHOOL,
+            is_active=True,
+            expiration=datetime.utcnow() + timedelta(days=30),
+            info={"source": CONTRIBUTION_GRANT_SOURCE},
+        )
+    )
+    # comp_only school: only a comp grant -> not "paying".
+    comp_only = School(
+        name="Comp Only", wriveted_identifier=uuid4(), state=SchoolState.ACTIVE
+    )
+    session.add(comp_only)
+    session.flush()
+    session.add(
+        Subscription(
+            id=_grant_id(comp_only),
+            product_id=CONTRIBUTION_GRANT_PRODUCT_ID,
+            stripe_customer_id="",
+            school_id=comp_only.wriveted_identifier,
+            type=SubscriptionType.SCHOOL,
+            is_active=True,
+            expiration=datetime.utcnow() + timedelta(days=30),
+            info={"source": CONTRIBUTION_GRANT_SOURCE},
+        )
+    )
+    session.commit()
+
+    rows = (
+        session.execute(
+            school_repository.get_all_query_with_optional_filters(
+                session, has_active_subscription=True
+            )
+        )
+        .scalars()
+        .all()
+    )
+    ids = [s.wriveted_identifier for s in rows]
+    # The paying school appears exactly once (no cartesian dupes from two rows).
+    assert ids.count(test_school.wriveted_identifier) == 1
+    # A comp-only school is not counted as "paying".
+    assert comp_only.wriveted_identifier not in ids
+
+
+# --- lapse sweep ---
+
+
+@pytest.mark.asyncio
+async def test_lapse_deactivates_expired_grant_not_stripe_schools(async_session):
+    from app.api.internal import handle_lapse_expired_schools
+
+    now = datetime.utcnow()
+    await async_session.merge(Product(id=CONTRIBUTION_GRANT_PRODUCT_ID, name="comp"))
+    real_price_id = f"price_real_{uuid4().hex[:8]}"
+    await async_session.merge(Product(id=real_price_id, name="Real"))
+    await async_session.flush()
+
+    # School A: expired grant, no Stripe subscription -> should lapse.
+    school_a = School(
+        name="Grant School", wriveted_identifier=uuid4(), state=SchoolState.ACTIVE
+    )
+    # School B: expired grant BUT a live Stripe subscription -> must stay ACTIVE.
+    school_b = School(
+        name="Stripe School", wriveted_identifier=uuid4(), state=SchoolState.ACTIVE
+    )
+    async_session.add_all([school_a, school_b])
+    await async_session.flush()
+
+    async_session.add_all(
+        [
+            Subscription(
+                id=f"{CONTRIBUTION_GRANT_SUBSCRIPTION_PREFIX}{school_a.wriveted_identifier}",
+                school_id=school_a.wriveted_identifier,
+                type=SubscriptionType.SCHOOL,
+                stripe_customer_id="",
+                is_active=True,
+                expiration=now - timedelta(days=1),
+                product_id=CONTRIBUTION_GRANT_PRODUCT_ID,
+                info={"source": CONTRIBUTION_GRANT_SOURCE},
+            ),
+            Subscription(
+                id=f"{CONTRIBUTION_GRANT_SUBSCRIPTION_PREFIX}{school_b.wriveted_identifier}",
+                school_id=school_b.wriveted_identifier,
+                type=SubscriptionType.SCHOOL,
+                stripe_customer_id="",
+                is_active=True,
+                expiration=now - timedelta(days=1),
+                product_id=CONTRIBUTION_GRANT_PRODUCT_ID,
+                info={"source": CONTRIBUTION_GRANT_SOURCE},
+            ),
+            Subscription(
+                id=f"sub_stripe_{uuid4().hex[:8]}",
+                school_id=school_b.wriveted_identifier,
+                type=SubscriptionType.SCHOOL,
+                stripe_customer_id="cus_real",
+                is_active=True,
+                expiration=now + timedelta(days=30),
+                product_id=real_price_id,
+            ),
+        ]
+    )
+    await async_session.commit()
+
+    result = await handle_lapse_expired_schools(async_session)
+
+    await async_session.refresh(school_a)
+    await async_session.refresh(school_b)
+    assert school_a.state == SchoolState.INACTIVE
+    assert school_b.state == SchoolState.ACTIVE
+    assert result["lapsed"] == 1

--- a/app/tests/unit/test_school_signup.py
+++ b/app/tests/unit/test_school_signup.py
@@ -7,7 +7,9 @@ import pytest
 from app.models.school import School
 from app.services import school_billing
 from app.services.school_emails import (
+    render_contribution_thankyou_html,
     render_school_activated_html,
+    render_school_contribution_notice_html,
     render_school_registered_html,
     render_school_staff_invite_html,
     render_staff_new_school_alert_html,
@@ -53,6 +55,39 @@ def test_staff_alert_lists_details_and_escapes():
     assert "w-123" in html
     assert "&lt;b&gt;Hack&lt;/b&gt;" in html  # escaped
     assert "<b>Hack</b>" not in html  # not raw
+
+
+def test_contribution_thankyou_credit_path_mentions_credit():
+    html = render_contribution_thankyou_html("St Kilda Primary", "50.00 AUD", "credited")
+    assert "St Kilda Primary" in html
+    assert "50.00 AUD" in html
+    assert "credited" in html.lower()
+    assert "live" not in html.lower()
+
+
+def test_contribution_thankyou_activation_mentions_live_and_date():
+    html = render_contribution_thankyou_html(
+        "St Kilda Primary", "50.00 AUD", "activated", access_until="2026-08-15"
+    )
+    assert "live" in html.lower()
+    assert "2026-08-15" in html
+
+
+def test_contribution_thankyou_extension_mentions_extended_and_date():
+    html = render_contribution_thankyou_html(
+        "St Kilda Primary", "50.00 AUD", "extended", access_until="2026-09-14"
+    )
+    assert "extended" in html.lower()
+    assert "2026-09-14" in html
+
+
+def test_contribution_notice_escapes_and_names_school():
+    html = render_school_contribution_notice_html(
+        "<b>Hack</b> School", "Alex", "50.00 AUD", "credited"
+    )
+    assert "Alex" in html
+    assert "&lt;b&gt;Hack&lt;/b&gt;" in html
+    assert "<b>Hack</b>" not in html
 
 
 # --- checkout session ---
@@ -115,3 +150,65 @@ async def test_create_checkout_session_rejects_unknown_price_id(monkeypatch):
     monkeypatch.setattr(school_billing.settings, "STRIPE_SECRET_KEY", "sk_test")
     with pytest.raises(school_billing.SchoolBillingError):
         await school_billing.create_school_checkout_session(_school(), price_id="price_other")
+
+
+# --- contribution checkout session ---
+
+
+@pytest.mark.asyncio
+async def test_create_contribution_session_builds_expected_params(monkeypatch):
+    monkeypatch.setattr(
+        school_billing.settings,
+        "STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS",
+        ["price_contrib"],
+    )
+    monkeypatch.setattr(school_billing.settings, "STRIPE_SECRET_KEY", "sk_test")
+    monkeypatch.setattr(
+        school_billing.settings, "HUEY_BOOKS_APP_URL", "https://hueybooks.com"
+    )
+
+    captured = {}
+
+    class FakeSession:
+        id = "cs_contrib_123"
+        url = "https://checkout.stripe.com/pay/cs_contrib_123"
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return FakeSession()
+
+    monkeypatch.setattr(school_billing.stripe.checkout.Session, "create", fake_create)
+
+    school = _school()
+    url = await school_billing.create_school_contribution_checkout_session(school)
+
+    assert url == "https://checkout.stripe.com/pay/cs_contrib_123"
+    assert captured["mode"] == "payment"
+    assert captured["line_items"] == [{"price": "price_contrib", "quantity": 1}]
+    assert captured["client_reference_id"] == str(school.wriveted_identifier)
+    assert captured["metadata"]["kind"] == "school_contribution"
+    assert captured["metadata"]["wriveted_school_id"] == str(school.wriveted_identifier)
+    assert "{CHECKOUT_SESSION_ID}" in captured["success_url"]
+
+
+@pytest.mark.asyncio
+async def test_create_contribution_session_requires_price_id(monkeypatch):
+    monkeypatch.setattr(
+        school_billing.settings, "STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS", []
+    )
+    with pytest.raises(school_billing.SchoolBillingError):
+        await school_billing.create_school_contribution_checkout_session(_school())
+
+
+@pytest.mark.asyncio
+async def test_create_contribution_session_rejects_unknown_price_id(monkeypatch):
+    monkeypatch.setattr(
+        school_billing.settings,
+        "STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS",
+        ["price_contrib"],
+    )
+    monkeypatch.setattr(school_billing.settings, "STRIPE_SECRET_KEY", "sk_test")
+    with pytest.raises(school_billing.SchoolBillingError):
+        await school_billing.create_school_contribution_checkout_session(
+            _school(), price_id="price_other"
+        )

--- a/docs/school-self-serve-signup.md
+++ b/docs/school-self-serve-signup.md
@@ -35,6 +35,13 @@ School state machine: `PENDING --paid--> ACTIVE --cancelled/ended--> INACTIVE`.
   email and lists staff. The colleague is created as an educator bound to the
   school and is linked to their account by email on first sign-in (an email that
   already has an account is rejected with 409). An invite email is sent.
+- `POST /v1/school/{wriveted_identifier}/contribute` (`app/api/schools.py`) —
+  new; a one-off "contribute a month" payment toward a school (see below).
+  Returns `{ "checkout_url": ... }`. Auth is **any authenticated active user or
+  service account** (not `Permission("update", ...)`), so a sponsor who is not
+  the school admin — a parent, public supporter, or library — can pay a shared
+  link. The school is resolved by `wriveted_identifier` (404 if missing). Stripe
+  SDK call is offloaded off the event loop.
 
 ## Payment → activation (the money-gates-access rule)
 
@@ -62,16 +69,128 @@ School state machine: `PENDING --paid--> ACTIVE --cancelled/ended--> INACTIVE`.
 | Staff invite | staff added to a school | the invited colleague |
 | "Your school is live" + receipt | paid activation | school contact / payer |
 | Renewal reminder | `invoice.upcoming` | school contact |
+| "Thank you for contributing" | contribution paid | the contributing supporter |
+| "A supporter contributed" | contribution paid | school contact (if different) |
+
+The two contribution emails state the accurate outcome — "credited your next
+invoice", "activated your school through &lt;date&gt;", or "extended your access
+to &lt;date&gt;".
 
 Copy is cadence-agnostic (no hardcoded "annual"); the renewal reminder pulls the
 amount and date from the invoice. Renderers live in
 `app/services/school_emails.py` and are unit-tested.
 
-### Planned: parent "contribute a month"
-The checkout is payer-agnostic, so the sponsorship path already works (forward
-the school checkout URL to a parent/library). The planned extension is a
-parent-facing offer — a one-off "sponsor a month" price plus an email/broadcast
-to a school's parents — that reuses the same school-scoped checkout. Not built.
+### Contribute a month
+
+A parent, public supporter, or library can contribute toward a specific
+school's subscription via a one-off payment. Like the school checkout, it is
+payer-agnostic and scoped to the school, so a shareable link works.
+
+```
+1. Contribute  POST /v1/school/{id}/contribute -> one-off Stripe Checkout URL (mode=payment)
+                                                -> supporter pays, or admin forwards the URL
+2. Credit/     webhook checkout.session.completed (metadata kind=school_contribution, paid)
+   grant        -> school has an active Stripe subscription: customer-balance credit
+                -> otherwise: create/extend a bounded comped grant + activate school
+                -> emails: accurate thank-you to payer (+ notice to school)
+3. Lapse       POST /v1/maintenance/lapse-expired-schools (Cloud Scheduler)
+                -> sets INACTIVE any school whose comped grant expired and that has
+                   no live Stripe subscription
+```
+
+- Endpoint: `app/api/schools.py :: create_school_contribution`.
+- Checkout builder: `app/services/school_billing.py ::
+  create_school_contribution_checkout_session` — `mode="payment"`,
+  `client_reference_id = school.wriveted_identifier`, and
+  `metadata={"kind": "school_contribution", "wriveted_school_id": ...,
+  "school_name": ...}`. Offloaded via `asyncio.to_thread`.
+
+#### Webhook handling (the crediting model)
+
+`app/services/stripe_events.py`:
+- `process_stripe_event` short-circuits contribution checkouts **strictly by
+  `metadata.kind == "school_contribution"`** (not by `mode`, which would swallow
+  any future one-off checkout) **before** the customer-centric extraction,
+  because a one-off (guest) checkout may have no Stripe customer. The school is
+  resolved directly from `client_reference_id`.
+- `_handle_contribution_checkout_completed` gates on `payment_status == "paid"`,
+  then applies the crediting model:
+  - **School has an active auto-renewing Stripe subscription** (determined by a
+    direct query for an active subscription with a non-empty `stripe_customer_id`,
+    not the ambiguous one-to-one relationship) → the contributed `amount_total`
+    is applied as a **Stripe customer-balance credit** on that subscription's
+    customer (`create_balance_transaction(amount=-amount_total, currency=...,
+    idempotency_key=...)`), reducing the next renewal invoice. The school state is
+    unchanged. Any leftover comped grant is retired (see below). Failure handling:
+    a **permanent** error — currency mismatch (validated against the customer's
+    balance currency first) or a Stripe `InvalidRequestError` — **fails soft**
+    (logged, recorded `credit_failed`); a **potentially transient** error (rate
+    limit, connection, API error) is **re-raised** so the idempotency claim is
+    rolled back and Cloud Tasks retries — the `idempotency_key` makes that retry
+    safe from double-crediting.
+  - **School has no such subscription** → the contribution buys a **bounded paid
+    grant proportional to the amount paid**. A first-class comped `Subscription`
+    is created — id `comp_contribution_<wriveted_id>`, `type=SCHOOL`,
+    `stripe_customer_id=""`, `info={"source": "contribution_grant"}` (so it is
+    clearly distinguishable from an auto-renewing Stripe subscription),
+    `expiration = now + grant_days` — and the school is activated. If a comped
+    grant already exists the expiry is **extended** by the newly-computed days
+    (contributions stack: from the current expiry if still in the future,
+    otherwise from now).
+
+#### Grant vs Stripe subscription (one active row)
+
+A comped grant and a real Stripe subscription are separate `subscriptions` rows.
+When a school gains/uses a real auto-renewing Stripe subscription (contribution
+credit path, subscription checkout, or `customer.subscription.created`), any
+active comped grant is **retired** (`is_active=False`) so the school never has two
+*active* subscription rows. Because a retired (inactive) grant row still exists,
+`School.subscription` (uselist=False) is ordered `is_active desc, expiration desc`
+so it deterministically resolves to the live subscription; the retired row is kept
+as an audit trail and is not orphan-deleted. Conversely,
+`customer.subscription.deleted` does **not** deactivate a school that still has an
+active, unexpired comped grant.
+
+The `GET /schools?has_active_subscription=` staff filter means **paying**: it
+matches via an `EXISTS` on an active subscription with a non-empty
+`stripe_customer_id`, so comped grants are excluded and a school with multiple
+subscription rows is not duplicated.
+
+#### Pay-what-you-want + proportional access
+
+Contributions are pay-what-you-want: the Stripe price uses `custom_unit_amount`,
+so the payer enters any amount (≥ the price's minimum) and
+`checkout.session.amount_total` varies per checkout. The credit path credits the
+actual `amount_total`. The grant path converts the amount into a proportional
+number of days against a notional monthly rate:
+`grant_days = max(1, min(round(amount_total / SCHOOL_CONTRIBUTION_MONTHLY_CENTS * 30), 3650))`
+(default rate 2500 = $25/mo, so $50 ≈ 60 days, $240 ≈ ~a year; clamped to 10 years
+so an absurd amount can't overflow the expiry datetime and wedge the webhook).
+
+#### Bounded-grant semantics + lapse
+
+The comped grant has no Stripe subscription behind it, so it does **not**
+auto-renew and there is no `customer.subscription.deleted` to lapse it. Instead,
+`POST /v1/maintenance/lapse-expired-schools` (`app/api/internal`) sweeps expired
+grants: for each active `contribution_grant` subscription past its expiry it marks
+the grant inactive and, unless the school has a live auto-renewing Stripe
+subscription (which Stripe drives), sets the school `INACTIVE`. A Cloud Scheduler
+job drives this on a cadence (wired in the infrastructure repo, not here).
+
+Trade-off: access is granted for a bounded, amount-proportional window and lapses
+cleanly after expiry, rather than persisting indefinitely. The contribution is
+never left as a dangling unusable credit: with no customer to credit, its value is
+realised as a grant.
+
+#### Idempotency
+
+Each contribution claims its checkout session id in
+`stripe_contribution_receipts` (PK = `checkout_session_id`) via
+`INSERT ... ON CONFLICT DO NOTHING` **before** doing any work. Concurrent Stripe
+redeliveries serialise on that key, so only the first delivery activates/extends
+and emails; the rest are full no-ops. The balance-credit call additionally passes
+a Stripe `idempotency_key` (`contribution-{session_id}`) so money can't be
+double-credited even independent of the receipt row.
 
 ## Sponsorship
 
@@ -86,6 +205,15 @@ paid. Bulk multi-school sponsorship in one transaction is future work.
 - `STRIPE_SCHOOL_PRICE_IDS` — offerable school price ids (comma-separated or
   JSON); the first is the default. Checkout accepts an optional `price_id` that
   must be one of these.
+- `STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS` — one-off "contribute a month" price
+  ids (comma-separated or JSON); the first is the default. `/contribute` accepts
+  an optional `price_id` that must be one of these. These must be **one-time**
+  Stripe prices used in `mode="payment"`, configured with `custom_unit_amount`
+  (pay-what-you-want).
+- `SCHOOL_CONTRIBUTION_MONTHLY_CENTS` — notional monthly rate (minor units,
+  default 2500) used to convert a pay-what-you-want contribution into a
+  proportional access grant (`grant_days = round(amount / this * 30)`) for a
+  school with no auto-renewing Stripe subscription. Contributions stack.
 - `STAFF_ALERT_EMAILS` — recipients for signup alerts (comma-separated or JSON),
   set per deployment; empty disables the alert.
 - `SCHOOL_ADMIN_URL` — where a school admin manages their school; used for links
@@ -102,12 +230,23 @@ paid. Bulk multi-school sponsorship in one transaction is future work.
 
 ## Testing
 
-- Unit: `app/tests/unit/test_school_signup.py` (email renderers, checkout param
-  building, missing-price error).
+- Unit: `app/tests/unit/test_school_signup.py` (email renderers, checkout and
+  contribution param building, missing/unknown-price errors).
 - Integration: `app/tests/integration/test_school_activation.py` — paid
   activates + emails once, unpaid does not activate, duplicate event does not
-  re-email, cancellation deactivates. Run with
-  `bash scripts/integration-tests.sh -k school_activation`.
+  re-email, cancellation deactivates.
+- Integration: `app/tests/integration/test_school_contribution.py` — routing
+  matches only on metadata kind; no-subscription contribution creates a bounded
+  proportional grant and activates; larger amounts grant more days; a repeat
+  contribution extends by the proportional days; an active Stripe subscription
+  gets a balance credit; currency mismatch and a permanent Stripe error fail soft
+  while a transient error re-raises (no committed claim); duplicate events are
+  no-ops; the grant→Stripe-subscription conversion retires the grant (one active
+  row, grant row preserved); a cancelled Stripe sub keeps a school active if it
+  has a live grant; the `has_active_subscription` filter excludes comps and
+  de-dupes; and the lapse sweep deactivates expired grants but not schools with a
+  live Stripe subscription. Run with
+  `bash scripts/integration-tests.sh -k "school_activation or school_contribution"`.
 
 ## Going live
 
@@ -119,7 +258,19 @@ setup + secret/price change, not code:
    `checkout.session.async_payment_succeeded`, `customer.subscription.deleted`,
    `invoice.upcoming`, `invoice.payment_failed`, plus the existing subscription
    events.
+   The `checkout.session.completed` event already covers contributions (same
+   event; distinguished by the `metadata.kind` marker); no extra webhook event is
+   needed. For contributions paid via bank transfer/other delayed methods also
+   enable `checkout.session.async_payment_succeeded`.
 2. Set the secrets/config: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`,
-   `STRIPE_SCHOOL_PRICE_IDS`, `EMAIL_PROVIDER=resend`, and `STAFF_ALERT_EMAILS`.
-3. Manual e2e: register a school → hit `/checkout` → pay with a Stripe test
+   `STRIPE_SCHOOL_PRICE_IDS`, `STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS`,
+   `SCHOOL_CONTRIBUTION_MONTHLY_CENTS` (optional, default 2500),
+   `EMAIL_PROVIDER=resend`, and `STAFF_ALERT_EMAILS`. The contribution price(s)
+   must be configured in Stripe with `custom_unit_amount` (pay-what-you-want).
+3. Wire a Cloud Scheduler job (OIDC, background-tasks service account) to
+   `POST /v1/maintenance/lapse-expired-schools` on the internal API so bounded
+   contribution grants lapse after expiry (done in the infrastructure repo).
+4. Manual e2e: register a school → hit `/checkout` → pay with a Stripe test
    card → confirm the school flips to ACTIVE and the receipt email sends.
+   Then hit `/contribute` on a school with no subscription → confirm a comped
+   grant is created and the school activates.

--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -62,6 +62,32 @@ Primary "someone paid" signal. Creates/updates the subscription and, for a
 payment methods, trials, or 100%-off promos). Activation is idempotent across
 Stripe's redeliveries.
 
+This event is also the signal for a one-off **school contribution** ("contribute
+a month"). Such sessions carry `metadata.kind == "school_contribution"`;
+`process_stripe_event` routes them (strictly on that marker, not on `mode`) to
+`_handle_contribution_checkout_completed` before the customer-centric extraction
+(a guest one-off checkout may have no Stripe customer). Gated on
+`payment_status == "paid"`. Crediting model:
+- if the school has an active auto-renewing Stripe subscription, the amount is
+  applied as a **customer-balance credit** (`create_balance_transaction(
+  amount=-amount_total, ...)`) toward the next renewal — currency-validated
+  against the customer. A permanent failure (currency mismatch / InvalidRequest)
+  fails soft (`credit_failed`); a transient Stripe error re-raises so the claim
+  rolls back and the task retries (idempotency-key-safe). Any leftover comped
+  grant is retired so the school keeps a single active subscription row.
+- otherwise the contribution buys a **bounded comped grant proportional to the
+  (pay-what-you-want) amount**: a first-class `Subscription`
+  (`info.source == "contribution_grant"`, no Stripe customer, `expiration = now +
+  round(amount / SCHOOL_CONTRIBUTION_MONTHLY_CENTS * 30)` days, clamped to 10y) is
+  created or extended and the school is activated. These grants lapse via
+  `POST /maintenance/lapse-expired-schools` (Cloud Scheduler), which sets a school
+  INACTIVE once its grant expires and it has no live Stripe subscription.
+  `customer.subscription.deleted` won't deactivate a school that still has an
+  active unexpired grant.
+
+Idempotent via `stripe_contribution_receipts` (session id PK, insert-on-conflict),
+plus a Stripe `idempotency_key` on the balance-transaction call.
+
 ### invoice.upcoming
 
 Fires ahead of a renewal charge. For an active school we email the contact a
@@ -75,8 +101,17 @@ Logged only. Stripe runs its own dunning retries; the final give-up arrives as
 ## School self-serve paid signup
 
 `POST /v1/school/{wriveted_identifier}/checkout` creates a Checkout Session
-(subscription mode) for `STRIPE_SCHOOL_PRICE_ID`, scoped to the school via
+(subscription mode) for `STRIPE_SCHOOL_PRICE_IDS`, scoped to the school via
 `client_reference_id` so an admin or a sponsor can pay it. Payment gates
-activation via the webhook above. Full design + the account-cutover checklist:
+activation via the webhook above.
+
+`POST /v1/school/{wriveted_identifier}/contribute` creates a one-off
+(`mode="payment"`) Checkout Session for `STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS`
+(pay-what-you-want prices, i.e. `custom_unit_amount`), also scoped to the school,
+so any authenticated supporter can contribute toward it. See the crediting model
+(balance credit vs bounded proportional grant) under `checkout.session.completed`
+above.
+
+Full design + the account-cutover checklist:
 [school-self-serve-signup.md](./school-self-serve-signup.md).
 


### PR DESCRIPTION
Replaces the auto-closed #682 (its base `feat/school-paid-signup` was deleted when #681 merged). Rebased onto `main`; contains only the contribution commit on top of the merged #681.
## What this adds
A payer-agnostic, **pay-what-you-want** one-off contribution toward a specific school's Huey Books subscription. Scoped to the school (`client_reference_id`), so a shareable link works.

## Endpoint
`POST /v1/school/{wriveted_identifier}/contribute` → `{ "checkout_url": ... }`
- One-off Stripe Checkout Session (`mode="payment"`) with `metadata={"kind":"school_contribution", ...}`. The contribution price uses `custom_unit_amount` (payer enters any amount ≥ the minimum), so `amount_total` varies per checkout.
- **Auth:** any authenticated active user or service account (not `Permission("update")`), so a sponsor who is not the school admin can pay a shared link.
- Stripe SDK call offloaded with `asyncio.to_thread`.

## Config
- `STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS: List[str]` (first is default; must be `custom_unit_amount` one-time prices).
- `SCHOOL_CONTRIBUTION_MONTHLY_CENTS: int = 2500` — notional monthly rate for the proportional grant calc.

## Webhook handling (crediting model)
`process_stripe_event` routes contribution checkouts **strictly by `metadata.kind == "school_contribution"`** (not by `mode`) to `_handle_contribution_checkout_completed`, before the customer-centric extraction (a guest one-off checkout may have no Stripe customer). Gated on `payment_status == "paid"`. Whether a school has an active auto-renewing Stripe subscription is determined by a direct query (active + non-empty `stripe_customer_id`), not the ambiguous one-to-one relationship.
- **School has an active auto-renewing Stripe subscription** → **customer-balance credit** of the actual `amount_total` toward the next invoice. Currency validated against the customer's balance currency; the Stripe call **fails soft** (logged, recorded `credit_failed`) rather than raising — a raise would poison the webhook.
- **School has no such subscription** → a **bounded paid grant proportional to the amount paid** (owner decision + pay-what-you-want): `grant_days = max(1, round(amount_total / SCHOOL_CONTRIBUTION_MONTHLY_CENTS * 30))` (default rate $25/mo → $50 ≈ 60 days, $240 ≈ ~a year). A first-class comped `Subscription` (id `comp_contribution_<wriveted_id>`, `type=SCHOOL`, `stripe_customer_id=""`, `info.source="contribution_grant"`) is created, or its expiry **extended** by the newly-computed days if one exists (contributions stack), and the school is activated.

## Lapse mechanism
`POST /v1/maintenance/lapse-expired-schools` (internal API): sweeps expired `contribution_grant` subscriptions, marks each inactive, and sets the school INACTIVE **unless** it has a live auto-renewing Stripe subscription (Stripe drives those). A Cloud Scheduler job will drive this on a cadence — wired separately in the infra repo.

## Idempotency (race-safe)
New `stripe_contribution_receipts` table (PK = `checkout_session_id`, via alembic migration). The webhook claims the session id with `INSERT ... ON CONFLICT DO NOTHING` before any work, so concurrent Stripe redeliveries serialise on the key and only the first activates/extends/emails. The balance-credit call also passes a Stripe `idempotency_key`.

## Emails
Accurate per-outcome: thank-you to the payer ("credited your next invoice" / "activated ... through &lt;date&gt;" / "extended your access to &lt;date&gt;") plus a notice to the school contact, both showing the contributed amount.

## Tests
- Unit (`test_school_signup.py`): outcome-aware renderers + contribution checkout params + price errors.
- Integration (`test_school_contribution.py`, mocks Stripe): routing only on metadata kind; no-subscription → proportional grant (~60 days for $50, ~180 for $150) + school ACTIVE; repeat extends by the proportional days; active Stripe sub → balance credit of actual amount; currency mismatch and Stripe error → soft-fail (`credit_failed`, no exception); duplicate event → no-op; lapse sweep deactivates expired grants but not schools with a live Stripe subscription.
- Results: unit `14 passed`; integration `14 passed` (contribution + activation) via the docker harness (migration runs there). `ruff check`/`format` + isort clean.

## Docs
`docs/school-self-serve-signup.md` and `docs/stripe.md` updated for pay-what-you-want, the proportional bounded grant, the lapse endpoint, config, currency handling, and idempotency.

## Addressed from review
- H3 (rebase): rebased onto current #681 tip; diff no longer reverts the is_active gate or the deleted activation-test assertion.
- H1/H2: bounded grant that lapses (was indefinite grant).
- Pay-what-you-want: `custom_unit_amount`; credit uses actual amount; grant length proportional via `SCHOOL_CONTRIBUTION_MONTHLY_CENTS` (replaced the fixed grant-days config).
- M1: route strictly on metadata kind.
- M2: race-safe idempotency via unique-key insert-conflict (migration).
- M3: currency validation + fail-soft + ISO-code money formatting (no hardcoded `$`).

## For reviewer
- Grant length is proportional to amount at a fixed notional monthly rate; it does not account for any partial period already credited on the credit path (credit and grant are mutually exclusive per contribution).
- The credit-vs-grant decision now queries the active Stripe subscription directly, so a school that has both a stale comped-grant row and a live Stripe subscription is handled correctly (credits the Stripe customer).

---

## Re-review round 2 fixes
- **HIGH — two subscription rows / `School.subscription` (uselist=False):** when a school gains/uses a real auto-renewing Stripe subscription (contribution credit path, `_handle_checkout_session_completed` paid, `customer.subscription.created` active), any active comped grant is now **retired** (`is_active=False`) so there's never a second *active* row. `School.subscription` is ordered `is_active desc, expiration desc` so it deterministically resolves to the live row. The credit-vs-grant decision already queries the active Stripe sub directly. Verified (test) that the retired grant row is **not** orphan-deleted on flush/commit. New test `test_grant_to_stripe_subscription_conversion_retires_grant` asserts one active row + correct supporter flag + grant row preserved.
- **MEDIUM — credit fail-soft losing recoverable credits:** `_apply_customer_balance_credit` now distinguishes permanent (currency mismatch / `stripe.error.InvalidRequestError` → soft-fail, `credit_failed`) from potentially-transient Stripe errors (→ **re-raise** before the idempotency claim commits, so Cloud Tasks retries; `idempotency_key` keeps retry double-credit-safe). Tests: `test_contribution_permanent_stripe_error_soft_fails`, `test_contribution_transient_stripe_error_reraises` (asserts no committed claim).
- **MEDIUM — cancellation ignoring a live comp grant:** `_handle_subscription_cancelled` now leaves a school ACTIVE if it still has an active, unexpired comp grant. Test `test_subscription_cancelled_keeps_school_active_with_live_grant`.
- **MEDIUM — `has_active_subscription` staff filter:** now means "paying" — an `EXISTS` on an active subscription with non-empty `stripe_customer_id` (excludes comp grants, and no cartesian dupes for multi-row schools). Test `test_has_active_subscription_filter_excludes_comps_and_dedupes`.
- **LOW — clamp:** `_contribution_grant_days` clamped to [1, 3650] days so an absurd amount can't overflow the expiry datetime.

Test results: unit `14 passed`; integration `18 passed` (contribution + activation) via the docker harness. ruff/isort/format clean.

Note: a school in the transient two-row state (one active + one retired) logs a benign `SAWarning: Multiple rows returned with uselist=False` on subscription load; the `order_by` guarantees the correct (live) row is returned. Flagging in case you'd prefer to suppress it.

