### PR TITLE
Fix app boot crash: NoDecode for CSV List[str] settings (PROD outage)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,10 +1,11 @@
 import enum
+import json
 from functools import lru_cache
-from typing import List, Optional, Union
+from typing import Annotated, List, Optional, Union
 
 from pydantic import AnyHttpUrl, DirectoryPath, HttpUrl, field_validator
 from pydantic_core.core_schema import FieldValidationInfo
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 from sqlalchemy import URL
 from sqlalchemy.engine import make_url
 from structlog import get_logger
@@ -273,17 +274,17 @@ class Settings(BaseSettings):
     STRIPE_SECRET_KEY: str = ""
     STRIPE_WEBHOOK_SECRET: str = ""
     # Stripe price ids offerable for a school subscription (first is the default).
-    STRIPE_SCHOOL_PRICE_IDS: List[str] = []
+    STRIPE_SCHOOL_PRICE_IDS: Annotated[List[str], NoDecode] = []
     # One-off Stripe price ids for a "contribute a month" payment toward a
     # school's subscription (first is the default).
-    STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS: List[str] = []
+    STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS: Annotated[List[str], NoDecode] = []
     # Notional monthly rate (in minor units, e.g. cents) used to convert a
     # pay-what-you-want contribution into a proportional access grant for a school
     # with no auto-renewing Stripe subscription: grant_days = round(amount /
     # this * 30). Contributions stack (extend the expiry).
     SCHOOL_CONTRIBUTION_MONTHLY_CENTS: int = 2500
     # Recipients for internal signup alerts (set per deployment). Empty disables.
-    STAFF_ALERT_EMAILS: List[str] = []
+    STAFF_ALERT_EMAILS: Annotated[List[str], NoDecode] = []
 
     @field_validator(
         "STRIPE_SCHOOL_PRICE_IDS",
@@ -293,8 +294,14 @@ class Settings(BaseSettings):
     )
     @classmethod
     def _split_csv_list(cls, v: Union[str, List[str]]) -> Union[str, List[str]]:
-        # Accept a comma-separated env string as well as a JSON list.
-        if isinstance(v, str) and not v.startswith("["):
+        # These fields are annotated NoDecode so pydantic-settings does not
+        # JSON-decode the raw env value before this validator (that decode raises
+        # on a plain "a,b" string). We therefore accept both a JSON array and a
+        # comma-separated string here.
+        if isinstance(v, str):
+            v = v.strip()
+            if v.startswith("["):
+                return json.loads(v)
             return [item.strip() for item in v.split(",") if item.strip()]
         return v
 

--- a/app/tests/unit/test_configuration.py
+++ b/app/tests/unit/test_configuration.py
@@ -4,3 +4,24 @@ from app.config import Settings
 def test_can_create_settings():
     config = Settings(POSTGRESQL_PASSWORD="test", SECRET_KEY="test")
     assert hasattr(config, "SECRET_KEY")
+
+
+def test_list_env_fields_parse_bare_csv_and_json(monkeypatch):
+    """List[str] settings must parse from a plain env string, not just JSON.
+
+    Regression: pydantic-settings JSON-decodes complex env values before field
+    validators run, so a bare "price_x" or "a,b" value raised SettingsError and
+    crashed app boot. The fields are annotated NoDecode so the CSV/JSON-aware
+    validator handles them. Must be set via the ENV source (kwargs bypass it).
+    """
+    for name in ("POSTGRESQL_PASSWORD", "SECRET_KEY", "SHOPIFY_HMAC_SECRET"):
+        monkeypatch.setenv(name, "test")
+    monkeypatch.setenv("STRIPE_SCHOOL_PRICE_IDS", "price_abc")
+    monkeypatch.setenv("STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS", "price_a, price_b")
+    monkeypatch.setenv("STAFF_ALERT_EMAILS", '["ops@example.com"]')
+
+    config = Settings()
+
+    assert config.STRIPE_SCHOOL_PRICE_IDS == ["price_abc"]
+    assert config.STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS == ["price_a", "price_b"]
+    assert config.STAFF_ALERT_EMAILS == ["ops@example.com"]


### PR DESCRIPTION
Prod /v1 returns 500: Settings() raised SettingsError parsing STRIPE_SCHOOL_PRICE_IDS. pydantic-settings 2.14.1 JSON-decodes List[str] env vars before validators run, so plain/CSV prod values crash boot on cold-start (latent since 07-16, exposed by overnight scale-to-zero). Fix: NoDecode on STRIPE_SCHOOL_PRICE_IDS / STRIPE_SCHOOL_CONTRIBUTION_PRICE_IDS / STAFF_ALERT_EMAILS + JSON-aware validator. Reproduced the crash on 3b0f62f and verified bare/CSV/JSON/unset all parse; regression test added.