### PR TITLE
Gate deploys on a real app boot (Cloud Run startup probe)

### DIFF
--- a/.cloudbuild/cloudbuild-main-branch.yaml
+++ b/.cloudbuild/cloudbuild-main-branch.yaml
@@ -27,6 +27,7 @@ steps:
       - services
       - update
       - $_SERVICE_NAME_DEVELOPMENT
+      - "--startup-probe=httpGet.path=/,httpGet.port=8000,initialDelaySeconds=5,timeoutSeconds=4,periodSeconds=8,failureThreshold=10"
       - "--platform=managed"
       - "--port=8000"
       - "--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
@@ -76,6 +77,7 @@ steps:
       - services
       - update
       - "$_SERVICE_NAME_DEVELOPMENT-internal"
+      - "--startup-probe=httpGet.path=/,httpGet.port=8000,initialDelaySeconds=5,timeoutSeconds=4,periodSeconds=8,failureThreshold=10"
       - "--platform=managed"
       - "--port=8000"
       - "--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
@@ -125,6 +127,7 @@ steps:
       - services
       - update
       - $_SERVICE_NAME
+      - "--startup-probe=httpGet.path=/,httpGet.port=8080,initialDelaySeconds=5,timeoutSeconds=4,periodSeconds=8,failureThreshold=10"
       - "--platform=managed"
       - "--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
       - "--region=$_DEPLOY_REGION"
@@ -176,6 +179,7 @@ steps:
       - services
       - update
       - "$_SERVICE_NAME-internal"
+      - "--startup-probe=httpGet.path=/,httpGet.port=8080,initialDelaySeconds=5,timeoutSeconds=4,periodSeconds=8,failureThreshold=10"
       - "--platform=managed"
       - "--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
       - "--region=$_DEPLOY_REGION"


### PR DESCRIPTION
## Why

Today's outage deployed "successfully" while the app couldn't serve `/v1`. The gunicorn master binds the port before its single worker imports the app, so an import-time crash (the `STRIPE_SCHOOL_PRICE_IDS` Settings failure) still passed Cloud Run's default **TCP** readiness check. `api.wriveted.com/` is served by Firebase Hosting, which masked it further. So a broken boot went live and only surfaced on cold-start hours later.

## Change

Add an HTTP **startup probe** on `/` (an app-served redirect, no DB) to all four deploy steps (dev + prod, public + internal). A revision now only becomes ready if the app actually imports and responds, so a failing boot **fails the deploy** and traffic stays on the last good revision.

- Ports match each service: dev `8000`, prod `8080`.
- `failureThreshold=10 × periodSeconds=8` → up to 80s boot window (generous vs the ~10-15s real boot), so no false negatives on slow cold-starts.

## Validation

Applied the exact probe to the **dev** service out-of-band: gcloud accepts the syntax and the healthy app passed (new revision became ready). Since the pipeline deploys dev before prod, a bad probe would fail at the dev step and never touch prod.

## Note

The `--startup-probe` I applied to `wriveted-api-development-main-branch` for testing will be reconciled by this pipeline on merge. Follow-up worth considering (see PR discussion): dropping gunicorn for a single uvicorn process on Cloud Run, which also makes boot crashes exit non-zero.