### PR TITLE
Drop gunicorn: run FastAPI under a single uvicorn process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Dependencies are managed with **uv** (`pyproject.toml` + `uv.lock`).
 | Lint fix | `uv run ruff check --fix` |
 | Add a dependency | `uv add <pkg>` (`--dev` for dev group) |
 | Run API directly | `uv run uvicorn app.main:app --reload` |
-| Run internal API | `uv run gunicorn --workers=1 --worker-class=uvicorn.workers.UvicornWorker app.internal_api:internal_app` |
+| Run internal API | `uv run uvicorn app.internal_api:internal_app --port 8888` |
 
 **Important**: Integration tests should be run using `bash scripts/integration-tests.sh` which provides the proper Docker environment. Running integration tests directly with pytest may encounter async fixture issues. Ensure no conflicting postgres containers are running on port 5432.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,11 @@ COPY --chown=${USER_UID}:${USER_GID} app/ /app/app
 
 USER ${USERNAME}
 
-# Run under gunicorn. Timeout 0 lets Cloud Run handle instance scaling.
-# When the PORT env var is defined, gunicorn binds 0.0.0.0:$PORT.
-ENTRYPOINT ["gunicorn", "--workers", "1", "--worker-class", "uvicorn.workers.UvicornWorker", "--threads", "1", "--timeout", "0"]
+# Run the ASGI app as a single uvicorn process; Cloud Run scales by instance,
+# so a process supervisor (gunicorn) adds no value here. sh -c expands $PORT
+# (Cloud Run sets it) and forwards the app path from CMD, or from a Cloud Run
+# --args override (e.g. the internal service uses app.internal_api:internal_app).
+# exec makes uvicorn PID 1 for signal handling; an import/boot failure exits
+# non-zero so the revision never goes healthy instead of serving a broken app.
+ENTRYPOINT ["sh", "-c", "exec uvicorn \"$@\" --host 0.0.0.0 --port \"${PORT:-8080}\"", "sh"]
 CMD ["app.main:app"]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The public API is available at `http://localhost:8000`. The seed script prints J
 uvicorn app.main:app --reload
 
 # Internal API
-gunicorn --workers=1 --worker-class=uvicorn.workers.UvicornWorker app.internal_api:internal_app
+uvicorn app.internal_api:internal_app --port 8888
 ```
 
 ### Configuring local admin access

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
 
   internal:
     image: "gcr.io/wriveted-api/wriveted-api:${TAG-latest}"
-    entrypoint: gunicorn --workers=1 --worker-class=uvicorn.workers.UvicornWorker --threads=1 --timeout=0 app.internal_api:internal_app
+    entrypoint: uvicorn app.internal_api:internal_app --host 0.0.0.0 --port 8888 --reload
     depends_on:
       - db
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "cryptography>=46.0.7,<49.0.0",
     "pydantic[email]>=2.7,<3",
     "fastapi_permissions>=0.2.7,<0.3",
-    "gunicorn>=23.0,<24",
     "tenacity>=9.0,<10",
     "sendgrid>=6.10,<7",
     "mock>=5.0.1,<6",

--- a/uv.lock
+++ b/uv.lock
@@ -1308,18 +1308,6 @@ wheels = [
 ]
 
 [[package]]
-name = "gunicorn"
-version = "23.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031, upload-time = "2024-08-10T20:25:27.378Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029, upload-time = "2024-08-10T20:25:24.996Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3498,7 +3486,6 @@ dependencies = [
     { name = "google-cloud-storage" },
     { name = "google-cloud-tasks" },
     { name = "google-genai" },
-    { name = "gunicorn" },
     { name = "httpx" },
     { name = "humanize" },
     { name = "isbnlib" },
@@ -3569,7 +3556,6 @@ requires-dist = [
     { name = "google-cloud-storage", specifier = ">=2.6.0,<3" },
     { name = "google-cloud-tasks", specifier = ">=2.10.4,<3" },
     { name = "google-genai", specifier = ">=1.0,<2" },
-    { name = "gunicorn", specifier = ">=23.0,<24" },
     { name = "httpx", specifier = ">=0.28,<0.29" },
     { name = "humanize", specifier = ">=4.4.0,<5" },
     { name = "isbnlib", specifier = ">=3.10.13,<4" },


### PR DESCRIPTION
## Why

Follow-up to the startup-probe fix (#686). On Cloud Run the platform is the process supervisor and autoscaler — it scales by *instance* (via `concurrency`), so wrapping a single uvicorn worker in gunicorn (`--workers 1`) added a layer with no benefit. It's also what masked today's outage: the gunicorn master binds `$PORT` before its worker imports the app, so an import crash still passed Cloud Run's default TCP readiness.

## Change

Run uvicorn directly as PID 1 via the image ENTRYPOINT:

```dockerfile
ENTRYPOINT ["sh", "-c", "exec uvicorn \"$@\" --host 0.0.0.0 --port \"${PORT:-8080}\"", "sh"]
CMD ["app.main:app"]
```

`sh -c` expands `$PORT` (Cloud Run sets it) and forwards the app path from `CMD` or a Cloud Run `--args` override — so the internal service (`--args=app.internal_api:internal_app`) keeps working unchanged. `exec` makes uvicorn PID 1 (clean SIGTERM), and an import/boot failure now exits non-zero on its own (defence-in-depth with the startup probe).

Also updates docker-compose (internal service), README, CLAUDE.md, and removes the `gunicorn` dependency. Behaviour is unchanged vs the old `gunicorn + UvicornWorker` (both used uvicorn's proxy-header/keep-alive defaults).

## Verification

Built the image and booted **both** apps against a local Postgres via the real ENTRYPOINT:
- public (default CMD, `PORT=8080`) → `/` 307, PID 1 = `uvicorn app.main:app --host 0.0.0.0 --port 8080`
- internal (`--args` override, `PORT=8888`) → `/` 307

No gunicorn in the process tree. The startup probe (#686) gates the actual deploy as a backstop.