### PR TITLE
Add activate CTA to the school registration email

### DIFF
--- a/app/api/onboarding.py
+++ b/app/api/onboarding.py
@@ -266,7 +266,9 @@ async def _queue_onboarding_emails(db, school, request):
                 "to_emails": [request.contact_email],
                 "subject": f"{school.name} — activate your Huey Books school",
                 "html_content": render_school_registered_html(
-                    school.name, request.contact_name
+                    school.name,
+                    request.contact_name,
+                    activate_url=f"{settings.HUEY_BOOKS_APP_URL.rstrip('/')}/school/activate",
                 ),
             },
             email_type=EmailType.ONBOARDING,

--- a/app/services/school_emails.py
+++ b/app/services/school_emails.py
@@ -21,14 +21,31 @@ def _shell(body_html: str) -> str:
     )
 
 
-def render_school_registered_html(school_name: str, contact_name: Optional[str]) -> str:
+def _button(url: str, label: str) -> str:
+    """A prominent call-to-action button (inline-styled for email clients)."""
+    return (
+        '<p style="margin:24px 0;">'
+        f'<a href="{escape(url, quote=True)}" '
+        'style="display:inline-block;background:#F22555;color:#ffffff;'
+        "text-decoration:none;padding:12px 28px;border-radius:9999px;"
+        f'font-weight:bold;">{escape(label)}</a></p>'
+    )
+
+
+def render_school_registered_html(
+    school_name: str,
+    contact_name: Optional[str],
+    activate_url: Optional[str] = None,
+) -> str:
     """Sent to the school contact once onboarding is submitted (pre-payment)."""
     greeting = f"Hi {escape(contact_name)}," if contact_name else "Hi there,"
+    cta = _button(activate_url, "Activate your school") if activate_url else ""
     return _shell(
         f"<h2>{escape(school_name)} is registered</h2>"
         f"<p>{greeting}</p>"
         "<p>Thanks for signing your school up to Huey Books. To activate your "
         "school's account, the last step is to start your subscription.</p>"
+        f"{cta}"
         "<p>Once payment is complete your school is live and your students can "
         "start reading.</p>"
         "<p>Happy reading,<br>The Huey Books team</p>"

--- a/app/tests/unit/test_school_signup.py
+++ b/app/tests/unit/test_school_signup.py
@@ -25,6 +25,15 @@ def test_school_registered_html_mentions_subscription_and_name():
     assert "subscription" in html.lower()
 
 
+def test_school_registered_html_includes_activate_cta_when_url_given():
+    url = "https://hueybooks.com/school/activate"
+    html = render_school_registered_html("St Kilda Primary", "Sarah", activate_url=url)
+    assert f'href="{url}"' in html
+    assert "Activate your school" in html
+    # No dangling link when no URL is supplied.
+    assert "href" not in render_school_registered_html("St Kilda Primary", "Sarah")
+
+
 def test_school_activated_html_no_contact_name_falls_back():
     html = render_school_activated_html("St Kilda Primary", None)
     assert "live" in html.lower()
@@ -58,7 +67,9 @@ def test_staff_alert_lists_details_and_escapes():
 
 
 def test_contribution_thankyou_credit_path_mentions_credit():
-    html = render_contribution_thankyou_html("St Kilda Primary", "50.00 AUD", "credited")
+    html = render_contribution_thankyou_html(
+        "St Kilda Primary", "50.00 AUD", "credited"
+    )
     assert "St Kilda Primary" in html
     assert "50.00 AUD" in html
     assert "credited" in html.lower()
@@ -149,7 +160,9 @@ async def test_create_checkout_session_rejects_unknown_price_id(monkeypatch):
     )
     monkeypatch.setattr(school_billing.settings, "STRIPE_SECRET_KEY", "sk_test")
     with pytest.raises(school_billing.SchoolBillingError):
-        await school_billing.create_school_checkout_session(_school(), price_id="price_other")
+        await school_billing.create_school_checkout_session(
+            _school(), price_id="price_other"
+        )
 
 
 # --- contribution checkout session ---


### PR DESCRIPTION
The registration email ("X is registered — start your subscription") had **no link** — a school admin who closed the tab had no way back to pay. Adds an **"Activate your school"** CTA button linking to `{HUEY_BOOKS_APP_URL}/school/activate` (the new page in huey-books-site #64). Renderer stays pure (URL passed from the caller). Audited the other school emails — activated + staff-invite already link to the admin UI; contribution/renewal are informational. Unit test added; `ruff` clean, unit tests pass.