### PR TITLE
Allow admin.hueybooks.com / api.hueybooks.com in CORS

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -214,6 +214,9 @@ class Settings(BaseSettings):
         # Huey Books Production URLs
         "https://hueybooks.com",
         "https://www.hueybooks.com",
+        # Admin UI served from these custom domains calls the API cross-origin.
+        "https://admin.hueybooks.com",
+        "https://api.hueybooks.com",
         # Firebase URLs
         "https://wriveted-library.web.app",
         "https://wriveted-api.web.app",


### PR DESCRIPTION
## Why
The admin UI is now served from **admin.hueybooks.com** (dashboard redirects there after PR site#66). Its API base is the absolute `https://api.wriveted.com`, so every `/v1` call from that origin is **cross-origin**. `BACKEND_CORS_ORIGINS` didn't include the new host, so the browser blocked the response — login (`/v1/auth/firebase`) failed with *'Access-Control-Allow-Origin missing'*.

Reproduced: `Origin: https://wriveted-api.web.app` → gets `access-control-allow-origin` echoed; `Origin: https://admin.hueybooks.com` → no such header.

## Change
Add `https://admin.hueybooks.com` and `https://api.hueybooks.com` (both serve the admin UI) to the `BACKEND_CORS_ORIGINS` allowlist. No wildcard, specific HTTPS origins we control.

## Deploy
Merges to main → `huey-books-backend-main` Cloud Build trigger deploys to the `wriveted-api` Cloud Run service.